### PR TITLE
Support image buttons with no "name" attribute

### DIFF
--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -356,7 +356,7 @@ class Mechanize
       form_node.search('input').each do |node|
         type = (node['type'] || 'text').downcase
         name = node['name']
-        next if name.nil? && !(type == 'submit' || type =='button')
+        next if name.nil? && !(type == 'submit' || type =='button' || type == 'image')
         case type
         when 'radio'
           @radiobuttons << RadioButton.new(node, self)

--- a/test/test_form_button.rb
+++ b/test/test_form_button.rb
@@ -21,6 +21,14 @@ class TestFormButtons < Test::Unit::TestCase
     assert_form_contains_button('<button type="button" value="submit"/>')
   end
 
+  def test_image_button_tag
+    assert_form_contains_button('<input type="image" name="submit" src="http://foo.com/image.jpg"/>')
+  end
+  
+  def test_no_name_image_button_tag
+    assert_form_contains_button('<input type="image" src="http://foo.com/image.jpg"/>')
+  end
+  
   def assert_form_contains_button(button)
     page = Mechanize::Page.new(nil, html_response, html(button), 200, @agent)
     assert_equal(1, page.forms.length)


### PR DESCRIPTION
small fix with test that correctly includes image buttons that have no "name" attribute, in the form's button list.
