### PR TITLE
dom_id accessor for *_with(:dom_id => "foo")

### DIFF
--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -250,6 +250,7 @@ class Mechanize
     # Find one field that matches +criteria+
     # Example:
     #   form.field_with(:dom_id => "exact_field_id").value = 'hello'
+    #   form.field_with(:id => "exact_field_id").value = 'hello' # :id works too!
 
     ##
     # :method: fields_with(criteria)
@@ -335,7 +336,11 @@ class Mechanize
           def #{plural}_with criteria = {}
             criteria = {:name => criteria} if String === criteria
             f = #{plural}.find_all do |thing|
-              criteria.all? { |k,v| v === thing.send(k) }
+              # criteria.all? { |k,v| v === thing.send(k) }
+              criteria.all? do |k,v| 
+                k = :dom_id if(k.to_s == "id")
+                v === thing.send(k)
+              end
             end
             yield f if block_given?
             f

--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -186,7 +186,11 @@ class Mechanize
           def #{type}s_with(criteria)
             criteria = {:name => criteria} if String === criteria
             f = #{type}s.find_all do |thing|
-              criteria.all? { |k,v| v === thing.send(k) }
+              # criteria.all? { |k,v| v === thing.send(k) }
+              criteria.all? do |k,v| 
+                k = :dom_id if(k.to_s == "id")
+                v === thing.send(k)
+              end
             end
             yield f if block_given?
             f

--- a/test/test_forms.rb
+++ b/test/test_forms.rb
@@ -530,10 +530,16 @@ class FormsMechTest < Test::Unit::TestCase
     # blatant copypasta of test above
     page = @agent.get("http://localhost/form_test.html")
     form = page.form_with(:dom_id => 'generic_form')
+    form_by_id = page.form_with(:id => 'generic_form')
+    
 
     assert_not_nil(form)
     assert_equal(1, form.fields_with(:dom_id => 'name_first').length)
     assert_equal('first_name', form.field_with(:dom_id => 'name_first').name)
+    
+    #  *_with(:id => blah) should work exactly like (:dom_id => blah)
+    assert_equal(form, form_by_id)
+    assert_equal(form.fields_with(:dom_id => 'name_first'), form.fields_with(:id => 'name_first'))
   end
 
   def test_add_field

--- a/test/test_links.rb
+++ b/test/test_links.rb
@@ -129,7 +129,9 @@ class LinksMechTest < Test::Unit::TestCase
   def test_links_dom_id
     page = @agent.get("http://localhost/tc_links.html")
     link = page.links_with(:dom_id => 'bold_aaron_link')
+    link_by_id = page.links_with(:id => 'bold_aaron_link')
     assert_equal(1, link.length)
     assert_equal('Aaron Patterson', link.first.text)
+    assert_equal(link, link_by_id)
   end
 end


### PR DESCRIPTION
Like I wrote in email -- I needed :dom_id (raw :id would be icky of course) for easy retrieving of given elements using form_with(:dom_id => 'blah') etc. 

Implemented for Form, Field and Link.
