### PR TITLE
Https referer

### DIFF
--- a/lib/mechanize/chain/header_resolver.rb
+++ b/lib/mechanize/chain/header_resolver.rb
@@ -30,8 +30,8 @@ class Mechanize
           request.add_field('Cookie', cookie)
         end
 
-        # Add Referer header to request
-        if referer && referer.uri
+        # Add Referer header to request except https => http
+        if referer && referer.uri && (!(URI::HTTPS === referer.uri) or URI::HTTPS === uri)
           request['Referer'] = referer.uri.to_s
         end
 

--- a/test/htdocs/tc_referer.html
+++ b/test/htdocs/tc_referer.html
@@ -1,6 +1,8 @@
 <html>
   <body>
     <a href="/referer">Referer Servlet</a>
+    <a href="http://localhost/referer">Referer Servlet forced to http</a>
+    <a href="https://localhost/referer">Referer Servlet forced to https</a>
     <br />
     <form method="post" action="/referer">
       <input type="text" name="first" /></br>

--- a/test/test_referer.rb
+++ b/test/test_referer.rb
@@ -36,4 +36,22 @@ class RefererTest < Test::Unit::TestCase
     page = @agent.submit page1.forms.first
     assert_equal("http://localhost/tc_referer.html", page.body)
   end
+
+  def test_http_to_https
+    page = @agent.get("http://localhost/tc_referer.html")
+    page = @agent.click page.links.last
+    assert_equal("http://localhost/tc_referer.html", page.body)
+  end
+
+  def test_https_to_https
+    page = @agent.get("https://localhost/tc_referer.html")
+    page = @agent.click page.links.last
+    assert_equal("https://localhost/tc_referer.html", page.body)
+  end
+
+  def test_https_to_http
+    page = @agent.get("https://localhost/tc_referer.html")
+    page = @agent.click page.links[1]
+    assert_equal("", page.body)
+  end
 end


### PR DESCRIPTION
Referer header shouldn't be set when the source is https and the dest is http.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec15.html#sec15.1.3

Could be an option, I guess. There's an option in FF. Reportedly not sent by IE. Not sent by Chrome (and presumably Safari). Not sure about Opera.
