### PR TITLE
Return nested inputs

### DIFF
--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -359,7 +359,7 @@ class Mechanize
       @checkboxes   = []
 
       # Find all input tags
-      form_node.search('input').each do |node|
+      form_node.search('.//input').each do |node|
         type = (node['type'] || 'text').downcase
         name = node['name']
         next if name.nil? && !(type == 'submit' || type =='button' || type == 'image')


### PR DESCRIPTION
There may be a HTML form that has nested inputs, e.g.:
&lt;form&gt;<br/>
&nbsp;&nbsp;&lt;ul&gt;&lt;li&gt;&lt;input type="text" name="i1"/&gt;&lt;/li&gt;&lt;/ul&gt;<br/>
&nbsp;&nbsp;&lt;input type="text" name="i2"/&gt;<br/>
&lt;/form&gt;

Currently mechanize will return only "i2" as a form field. It is suggested that it should return all the inputs from the form - "i1" and "i2" in this case and this fix is to provide that.

form_node.serch(".//input") xpath returns all input nodes of the form node.
