### PR TITLE
Fix issue with computing length of files with multibyte characters

### DIFF
--- a/lib/mechanize/chain/response_reader.rb
+++ b/lib/mechanize/chain/response_reader.rb
@@ -12,7 +12,7 @@ class Mechanize
         body = StringIO.new
         total = 0
         @response.read_body { |part|
-          total += part.length
+          total += (part.respond_to?(:bytesize) ? part.bytesize : part.length)
           body.write(part)
           Mechanize.log.debug("Read #{total} bytes") if Mechanize.log
         }


### PR DESCRIPTION
See issue #83.

This uses bytesize on the string if that method is defined, otherwise false back to length.
