### PR TITLE
Add support for leading dot in cookie domain

### DIFF
--- a/test/test_cookie_jar.rb
+++ b/test/test_cookie_jar.rb
@@ -118,7 +118,7 @@ class CookieJarTest < Test::Unit::TestCase
     assert_equal(0, jar.cookies(URI.parse('http://google.com/')).length)
   end
 
-  def test_add_rejects_cookies_for_TLDs
+  def test_add_rejects_cookies_that_do_not_contain_an_embedded_dot
     url = URI.parse('http://rubyforge.org/')
 
     jar = Mechanize::CookieJar.new
@@ -132,17 +132,57 @@ class CookieJarTest < Test::Unit::TestCase
     assert_equal(0, jar.cookies(url).length)
   end
 
-  def test_domain_mimics_browser_behavior_for_subdomains
-    url = URI.parse('http://admin.rubyforge.org/')
+  def test_add_makes_exception_for_local_tld
+    url = URI.parse('http://example.local')
 
     jar = Mechanize::CookieJar.new
-    cookie = cookie_from_hash(cookie_values)
+    tld_cookie = cookie_from_hash(cookie_values(:domain => '.local'))
+    jar.add(url, tld_cookie)
+
+    assert_equal(1, jar.cookies(url).length)
+  end
+
+  def test_add_makes_exception_for_localhost
+    url = URI.parse('http://localhost')
+
+    jar = Mechanize::CookieJar.new
+    tld_cookie = cookie_from_hash(cookie_values(:domain => 'localhost'))
+    jar.add(url, tld_cookie)
+
+    assert_equal(1, jar.cookies(url).length)
+  end
+
+  def test_add_cookie_for_the_parent_domain
+    url = URI.parse('http://x.foo.com')
+
+    jar = Mechanize::CookieJar.new
+    cookie = cookie_from_hash(cookie_values(:domain => '.foo.com'))
+    jar.add(url, cookie)
+
+    assert_equal(1, jar.cookies(url).length)
+  end
+
+  def test_add_rejects_cookies_from_a_nested_subdomain
+    url = URI.parse('http://y.x.foo.com')
+
+    jar = Mechanize::CookieJar.new
+    cookie = cookie_from_hash(cookie_values(:domain => '.foo.com'))
     jar.add(url, cookie)
 
     assert_equal(0, jar.cookies(url).length)
   end
 
-  def test_domain_mimics_browser_behavior_for_leading_dot
+  def test_cookie_without_leading_dot_does_not_match_subdomains
+    url = URI.parse('http://admin.rubyforge.org/')
+
+    jar = Mechanize::CookieJar.new
+    cookie = cookie_from_hash(cookie_values(:domain => 'rubyforge.org'))
+    jar.add(url, cookie)
+
+    assert_equal(0, jar.cookies(url).length)
+  end
+
+  def test_cookies_with_leading_dot_match_subdomains
     url = URI.parse('http://admin.rubyforge.org/')
 
     jar = Mechanize::CookieJar.new


### PR DESCRIPTION
Hi Aaron and Mike,

According to [RFC 2109](http://www.ietf.org/rfc/rfc2109.txt), a '.y.com' cookie domain matches any subdomain of y.com.

We have changed the CookieJar#cookies method to match based on this rule. Any cookies that do not start with a period are now anchored on both sides when matching against the URI.

This makes mechanize more closely match the behavior of browsers. We checked this in Chrome, Safari, and Firefox.

Please take a look at this patch and let us know what you think. We are open to any suggestions or recommendations.

Thanks,
Rob Olson and Damon McCormick
