### PR TITLE
support for accept-charset on form

### DIFF
--- a/lib/mechanize/util.rb
+++ b/lib/mechanize/util.rb
@@ -7,6 +7,15 @@ class Mechanize::Util
     :SJIS => "SHIFT_JIS",
     :UTF8 => "UTF-8", :UTF16 => "UTF-16", :UTF32 => "UTF-32"}
 
+  # true if RUBY_VERSION is 1.9.0 or later
+  NEW_RUBY_ENCODING = RUBY_VERSION >= '1.9.0'
+  # contains encoding error classes to raise
+  ENCODING_ERRORS = if NEW_RUBY_ENCODING
+                      [EncodingError]
+                    else
+                      [Iconv::InvalidEncoding, Iconv::IllegalSequence]
+                    end
+
   def self.build_query_string(parameters, enc=nil)
     parameters.map { |k,v|
       # WEBrick::HTTP.escape* has some problems about m17n on ruby-1.9.*.
@@ -14,6 +23,7 @@ class Mechanize::Util
     }.compact.join('&')
   end
 
+  # Mechanize does not use it anymore
   def self.to_native_charset(s, code=nil)
     if Mechanize.html_parser == Nokogiri::HTML
       return unless s
@@ -24,21 +34,33 @@ class Mechanize::Util
     end
   end
 
-  def self.from_native_charset(s, code, encode_option=nil, log=nil)
+  # convert string +s+ from +code+ to UTF-8.
+  # by String#encode (ruby 1.9.0 or later) or Iconv.conv (ruby 1.8.x)
+  def self.from_native_charset(s, code, ignore_encoding_error=false, log=nil)
     return s unless s && code
     return s unless Mechanize.html_parser == Nokogiri::HTML
 
-    if RUBY_VERSION < '1.9.2'
-      begin
-        Iconv.iconv(code.to_s, "UTF-8", s).join("")
-      rescue Iconv::InvalidEncoding
-        log.info("from_native_charset: Iconv::InvalidEncoding: #{code}") if log
+    begin
+      encode_to(code, s)
+    rescue *ENCODING_ERRORS => ex
+      log.debug("from_native_charset: #{ex.class}: form encoding: #{code.inspect} string: #{s}") if log
+      if ignore_encoding_error
         s
+      else
+        raise
       end
-    else
-      s.encode(code, encode_option)
     end
   end
+
+  # inner convert method of Util.from_native_charset
+  def self.encode_to(encoding, str)
+    if NEW_RUBY_ENCODING
+      str.encode(encoding)
+    else
+      Iconv.conv(encoding.to_s, "UTF-8", str)
+    end
+  end
+  private_class_method :encode_to
 
   def self.html_unescape(s)
     return s unless s

--- a/test/test_mechanize_util.rb
+++ b/test/test_mechanize_util.rb
@@ -1,7 +1,92 @@
-require "helper"
+# coding: utf-8
+require 'helper'
 
 class TestMechanizeUtil < Test::Unit::TestCase
+
+  INPUTTED_VALUE = "テスト" # "test" in Japanese UTF-8 encoding
+  CONTENT_ENCODING = 'Shift_JIS' # one of Japanese encoding
+  ENCODED_VALUE = "\x83\x65\x83\x58\x83\x67" # "test" in Japanese Shift_JIS encoding
+
+  if Mechanize::Util::NEW_RUBY_ENCODING
+    ENCODING_ERRORS = [EncodingError, Encoding::ConverterNotFoundError] # and so on
+    ERROR_LOG_MESSAGE = /from_native_charset: Encoding::ConverterNotFoundError: form encoding: "UTF-eight"/
+    ENCODED_VALUE.force_encoding(::Encoding::SHIFT_JIS)
+  else
+    ENCODING_ERRORS = [Iconv::InvalidEncoding, Iconv::IllegalSequence]
+    ERROR_LOG_MESSAGE = /from_native_charset: Iconv::InvalidEncoding: form encoding: "UTF-eight"/
+  end
+
+  INVALID_ENCODING = 'UTF-eight'
+
+  def setup
+    @result = "non_nil"
+  end
+
   def test_from_native_charset
-    assert_equal 'foo', Mechanize::Util.from_native_charset('foo', nil)
+    @result = Mechanize::Util.from_native_charset(INPUTTED_VALUE, CONTENT_ENCODING)
+    assert_equal ENCODED_VALUE, @result
+  end
+
+  def test_from_native_charset_returns_nil_when_no_string
+    @result = Mechanize::Util.from_native_charset(nil, CONTENT_ENCODING)
+    assert_equal nil, @result
+  end
+
+  def test_from_native_charset_doesnot_convert_when_no_encoding
+    @result = Mechanize::Util.from_native_charset(INPUTTED_VALUE, nil)
+    assert_not_equal ENCODED_VALUE, @result
+    assert_equal INPUTTED_VALUE, @result
+  end
+
+  def test_from_native_charset_doesnot_convert_when_not_nokogiri
+    parser = Mechanize.html_parser
+    Mechanize.html_parser = 'Another HTML Parser'
+
+    @result = Mechanize::Util.from_native_charset(INPUTTED_VALUE, CONTENT_ENCODING)
+    assert_not_equal ENCODED_VALUE, @result
+    assert_equal INPUTTED_VALUE, @result
+
+    Mechanize.html_parser = parser
+  end
+
+  def test_from_native_charset_raises_error_with_bad_encoding
+    assert_raise(*ENCODING_ERRORS){
+      @result = Mechanize::Util.from_native_charset(INPUTTED_VALUE, INVALID_ENCODING)
+    }
+  end
+
+  def test_from_native_charset_suppress_encoding_error_when_3rd_arg_is_true
+    assert_nothing_raised(*ENCODING_ERRORS){
+      @result = Mechanize::Util.from_native_charset(INPUTTED_VALUE, INVALID_ENCODING, true)
+    }
+  end
+
+  def test_from_native_charset_doesnot_convert_when_encoding_error_raised_and_ignored
+    @result = Mechanize::Util.from_native_charset(INPUTTED_VALUE, INVALID_ENCODING, true)
+
+    assert_not_equal ENCODED_VALUE, @result
+    assert_equal INPUTTED_VALUE, @result
+  end
+
+  def test_from_native_charset_logs_form_when_encoding_error_raised
+    sio = StringIO.new
+    log = Logger.new(sio)
+    log.level = Logger::DEBUG
+
+    assert_raise(*ENCODING_ERRORS){
+      @result = Mechanize::Util.from_native_charset(INPUTTED_VALUE, INVALID_ENCODING, nil, log)
+    }
+    assert_match ERROR_LOG_MESSAGE, sio.string
+  end
+
+  def test_from_native_charset_logs_form_when_encoding_error_is_ignored
+    sio = StringIO.new
+    log = Logger.new(sio)
+    log.level = Logger::DEBUG
+
+    assert_nothing_raised(*ENCODING_ERRORS){
+      @result = Mechanize::Util.from_native_charset(INPUTTED_VALUE, INVALID_ENCODING, true, log)
+    }
+    assert_match ERROR_LOG_MESSAGE, sio.string
   end
 end


### PR DESCRIPTION
Rewrite my poor Engrish in the commit to cool one.

This old commit (cf9a4e5140603eab336bdef06349e54a6bd2eee4) seems that "ignore Iconv::IlligalSequence for Rails3 default form HTML".
However, Iconv::IlligalSequence at form is very important for multi-encoding users.
This error means that the form encoding is mismatch and sent data may be broken. Please don't ignore it.

**support of &lt;form accept-charset="enc"&gt;**

Rails3 default form has "accept-charset" as well as other up-to-date forms. Mechanize reads it and use as from_native_charset encoding. 

**Form#encoding= overwrites or sets accept-charset**

"accept-charset" is also set by Form#encoding=. Default is Page#encoding.

If you wish to send form in E2 encoding from encoding E1 page,

```
agent.get(uri_E1)
agent.page.encoding = E1
agent.page.forms[0].encoding = E2
```

the encoding of page is still E1.

**All Encoding class error raises on Ruby 1.9.2**

You can get information about encoding error now.

**Form#encoding= accepts String#encode option on Ruby 1.9.2**

If you want to inhibit encoding error (and send broken data to server) on Ruby 1.9.2,

```
agent.get(uri_E1)
agent.page.encoding = E1
agent.page.forms[0].encoding = E2, {:invalid => :replace, :undef => :replace}
```

the Hash is String#encode option.

**Iconv::InvalidEncoding on Ruby 1.9.1 or earlier is logged and ignored**
**Iconv::IllegalSequence on Ruby 1.9.1 or earlier raises**

You can get information about iconv error..
