### PR TITLE
Mechanize 2.0.0 with robots cannot get anything when robots.txt is 404

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -938,9 +938,9 @@ class Mechanize
 
   def webrobots_http_get(uri)
     get_file(uri)
-  rescue Net::HTTPExceptions => e
-    case e.response
-    when Net::HTTPNotFound
+  rescue Mechanize::ResponseCodeError => e
+    case e.response_code
+    when '404'
       ''
     else
       raise e

--- a/test/test_robots.rb
+++ b/test/test_robots.rb
@@ -8,6 +8,14 @@ class TestRobots < Test::Unit::TestCase
     }
   end
 
+  def test_mechanize_webrobots_http_get
+    robotstxt = @agent.__send__(:webrobots_http_get, 'http://localhost/robots.txt')
+    assert_not_equal '', robotstxt
+
+    robotstxt = @agent.__send__(:webrobots_http_get, 'http://localhost/response_code?code=404')
+    assert_equal '', robotstxt
+  end
+
   def test_robots
     assert_equal "Welcome!", @robot.get("http://localhost/robots.html").title
 


### PR DESCRIPTION
Mechanize#webrobots_http_get does not rescue when robots.txt is 404.

```
# lib/mechanize.rb, line939-
def webrobots_http_get(uri)
  get_file(uri)
  rescue Net::HTTPExceptions => e
    case e.response
    when Net::HTTPNotFound
      ''
    else
      raise e
    end
  end
end
```

because Mechanize raises Mechanize::ResponseCodeError when "404 Not Found".
