### PR TITLE
No easy way to set proxy.  Right now have to do:

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -235,6 +235,11 @@ class Mechanize
   end
 
   # Proxy settings
+
+  def set_proxy(addr,port)
+    @agent.set_proxy(addr,port)
+  end 
+
   attr_reader :proxy_addr
   attr_reader :proxy_pass
   attr_reader :proxy_port


### PR DESCRIPTION
agent = Mechanize.new
agent.agent.set_proxy('addr',8000)
should delegate setting proxy to the internal @agent

agent.set_proxy(addr,port)
