### PR TITLE
Mechanize#content_encoding_hooks

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -261,6 +261,12 @@ class Mechanize
     @agent.pre_connect_hooks
   end
 
+  # An array of hooks(Proc objects) to #call before reading response header 'content-encoding'.
+  #    agent.content_encoding_hooks << lambda{|httpagent, uri, http_response, response_body_io| ... }
+  def content_encoding_hooks
+    @agent.content_encoding_hooks
+  end
+
   alias follow_redirect? redirect_ok
 
   @html_parser = Nokogiri::HTML

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -31,6 +31,8 @@ class Mechanize::HTTP::Agent
 
   attr_reader :pre_connect_hooks
 
+  attr_reader :content_encoding_hooks
+
   # Length of time to attempt to read data from the server
   attr_accessor  :read_timeout
 
@@ -83,6 +85,7 @@ class Mechanize::HTTP::Agent
     @auth_hash            = {} # Keep track of urls for sending auth
     @conditional_requests = true
     @context              = nil
+    @content_encoding_hooks = []
     @cookie_jar           = Mechanize::CookieJar.new
     @digest               = nil # DigestAuth Digest
     @digest_auth          = Net::HTTP::DigestAuth.new
@@ -208,6 +211,8 @@ class Mechanize::HTTP::Agent
 
       res
     }
+
+    hook_content_encoding response, uri, response_body_io
 
     response_body = response_content_encoding response, response_body_io
 
@@ -495,6 +500,12 @@ class Mechanize::HTTP::Agent
     else
       raise Mechanize::Error,
             "Unsupported Content-Encoding: #{response['Content-Encoding']}"
+    end
+  end
+
+  def hook_content_encoding response, uri, response_body_io
+    @content_encoding_hooks.each do |hook|
+      hook.call self, uri, response, response_body_io
     end
   end
 

--- a/test/servlets.rb
+++ b/test/servlets.rb
@@ -126,7 +126,7 @@ class GzipServlet < WEBrick::HTTPServlet::AbstractServlet
       else
         res.body = ''
       end
-      res['Content-Encoding'] = 'gzip'
+      res['Content-Encoding'] = req['X-ResponseContentEncoding'] || 'gzip'
       res['Content-Type'] = "text/html"
     else
       res.code = 400

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -354,6 +354,38 @@ class TestMechanize < MiniTest::Unit::TestCase
     assert_match('Hello World', page.body)
   end
 
+  def test_content_encoding_hooks_header
+    h = {'X-ResponseContentEncoding' => 'agzip'}
+
+    # test of X-ResponseContentEncoding feature
+    assert_raises(Mechanize::Error, 'Unsupported Content-Encoding: agzip') do
+      @mech.get("http://localhost/gzip?file=index.html", nil, nil, h)
+    end
+
+    @mech.content_encoding_hooks << lambda{|agent, uri, response, response_body_io|
+      response['content-encoding'] = 'gzip' if response['content-encoding'] == 'agzip'}
+
+    page = @mech.get("http://localhost/gzip?file=index.html", nil, nil, h)
+
+    assert_match('Hello World', page.body)
+  end
+
+  def external_cmd(io); Zlib::GzipReader.new(io).read; end
+
+  def test_content_encoding_hooks_body_io
+    h = {'X-ResponseContentEncoding' => 'unsupported_content_encoding'}
+
+   @mech.content_encoding_hooks << lambda{|agent, uri, response, response_body_io|
+      if response['content-encoding'] == 'unsupported_content_encoding'
+        response['content-encoding'] = 'none'
+        response_body_io.string = external_cmd(response_body_io)
+      end}
+
+    page = @mech.get("http://localhost/gzip?file=index.html", nil, nil, h)
+
+    assert_match('Hello World', page.body)
+  end
+
   def test_get_http_refresh
     @mech.follow_meta_refresh = true
     page = @mech.get('http://localhost/http_refresh?refresh_time=0')

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -440,6 +440,17 @@ class TestMechanizeHttpAgent < MiniTest::Unit::TestCase
     assert_equal 'Unsupported Content-Encoding: unknown', e.message
   end
 
+  def test_hook_content_encoding_response
+    @mech.content_encoding_hooks << lambda{|agent, uri, response, response_body_io|
+      response['content-encoding'] = 'gzip' if response['content-encoding'] == 'agzip'}
+
+    @res.instance_variable_set :@header, 'content-encoding' => %w[agzip]
+    body_io = StringIO.new 'part'
+    @agent.hook_content_encoding @res, @uri, body_io
+
+    assert_equal 'gzip', @res['content-encoding']
+  end
+
   def test_response_cookies
     uri = URI.parse 'http://host.example.com'
     cookie_str = 'a=b domain=.example.com'


### PR DESCRIPTION
This is from #124

There is nothing to do for users when Mechanize raises "unsupported content-encoding" errors.
Because users can not touch response headers and response body before/after errors and they can not change the server behaviours, too.

With this commit, if you want Mechanize to treat 'Content-Encoding: agzip' and 'Content-Type: gzip' similarly,

```
agent.content_encoding_hooks << lambda{|httpagent, uri, response, body_io|
  response['content-encoding'] = 'gzip' if response['content-encoding'] == 'agzip'
}
```

(it may be useful for accessing iTunes Connect, like https://github.com/alexvollmer/itunes-connect/blob/9ec3990f88f16bb577e3a0fcbec34e705a396593/lib/itunes_connect/connection.rb )

if you want to accept bzip2 from supported server, add "accept-encoding: bzip2" and

```
agent.content_encoding_hooks << lambda{|httpagent, uri, response, body_io|
  if response['content-encoding'] == 'bzip2'
    response['content-encoding'] = nil
    body_io.string = bunzip2(body_io.string)
  end
}
```
