### PR TITLE
sending formdata in HTML order

### DIFF
--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -195,16 +195,16 @@ class Mechanize
       query = []
       @mech.log.info("form encoding: #{encoding}") if @mech && @mech.log
 
+      successful_controls = []
+
       (fields + checkboxes).sort.each do |f|
         case f
         when Form::CheckBox
           if f.checked
-            qval = proc_query(f)
-            query.push(*qval)
+            successful_controls << f
           end
         when Form::Field
-          qval = proc_query(f)
-          query.push(*qval)
+          successful_controls << f
         end
       end
 
@@ -221,8 +221,7 @@ class Mechanize
 
         if checked.size == 1
           f = checked.first
-          qval = proc_query(f)
-          query.push(*qval)
+          successful_controls << f
         elsif checked.size > 1
           raise Mechanize::Error,
                 "multiple radiobuttons are checked in the same group!"
@@ -230,9 +229,14 @@ class Mechanize
       end
 
       @clicked_buttons.each { |b|
-        qval = proc_query(b)
-        query.push(*qval)
+        successful_controls << b
       }
+
+      successful_controls.sort.each do |ctrl|
+        qval = proc_query(ctrl)
+        query.push(*qval)
+      end
+
       query
     end
 

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -573,4 +573,21 @@ class TestMechanizeForm < MiniTest::Unit::TestCase
       form.foo
     }
   end
+
+  def test_form_build_query
+    page = @agent.get("http://localhost/form_test.html")
+    get_form = page.forms.find { |f| f.name == "get_form2" }
+
+    # Now set all the fields
+    get_form.fields.find { |f| f.name == "first_name" }.value = "Aaron"
+    get_form.radiobuttons.find { |f|
+      f.name == "gender" && f.value == "male"
+    }.checked = true
+    get_form.checkboxes.find { |f| f.name == "likes ham" }.checked = true
+
+    query = get_form.build_query
+
+    assert_equal([["first_name", "Aaron"], ["gender", "male"], ["likes ham", "on"]], query)
+  end
+
 end


### PR DESCRIPTION
Mechanize 1.0.0/2.0 does not send form data in HTML order.

```
require 'rubygems'; require 'mechanize'
body = <<BODY
<html><form name="f1">
  <input type="radio" name="1" value="RADIO" checked>
  <input type="text"  name="2" value="TEXT">
</form></html>
BODY
mech = Mechanize.new
page = Mechanize::Page.new(URI.parse('http://example.com/'),
                           {'content-type' => 'text/html'},
                           body,
                           '200',
                           mech)
p page.form_with(:name => 'f1').request_data
```

shows:

```
"2=TEXT&1=RADIO"
```

The modern browsers send "1=RADIO&2=TEXT".
