### PR TITLE
test for incorrect encoding when searching nodes

### DIFF
--- a/test/test_mechanize_page_encoding.rb
+++ b/test/test_mechanize_page_encoding.rb
@@ -144,4 +144,12 @@ class TestMechanizePageEncoding < MiniTest::Unit::TestCase
 
     assert_equal 'ISO-8859-2', page.encoding
   end
+
+  def test_parser_encoding_when_searching_elements
+    body = '<span id="isoencoded">hi</span>'
+    page = util_page body
+    us_encoded_string = page.search('#isoencoded').text.encoding.to_s
+
+    assert_equal page.encoding, us_encoded_string
+  end
 end


### PR DESCRIPTION
test case for issue #130.
