### PR TITLE
fix for mechanize raise exception on some websites due to missing content_type

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -33,7 +33,7 @@ class Mechanize
 
   ##
   # The version of Mechanize you are using.
-  VERSION = '2.0.2'
+  VERSION = '2.0.2.doxo'
 
   class Error < RuntimeError
   end

--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -334,7 +334,7 @@ class Mechanize::Page < Mechanize::File
   end
 
   def self.charset content_type
-    charset = content_type[/charset=([^; ]+)/i, 1]
+    content_type && charset = content_type[/charset=([^; ]+)/i, 1]
     return nil if charset == 'none'
     charset
   end


### PR DESCRIPTION
@ page.rb:337, the content_type can be nil when mechanize parse some websites (e.g. www.att.com, after sign-in) added a simple check. 
