### PR TITLE
Send cookie for '.example.com' on requests for 'example.com' (Issue #136)

### DIFF
--- a/lib/mechanize/cookie_jar.rb
+++ b/lib/mechanize/cookie_jar.rb
@@ -40,7 +40,7 @@ class Mechanize::CookieJar
     domains = @jar.find_all { |domain, _|
       cookie_domain = self.class.strip_port(domain)
       if cookie_domain.start_with?('.')
-        url.host =~ /#{Regexp.escape cookie_domain}$/i
+        url.host =~ /(^|\.)#{Regexp.escape cookie_domain[1..-1]}$/i
       else
         url.host =~ /^#{Regexp.escape cookie_domain}$/i
       end

--- a/test/test_mechanize_cookie_jar.rb
+++ b/test/test_mechanize_cookie_jar.rb
@@ -184,6 +184,22 @@ class TestMechanizeCookieJar < MiniTest::Unit::TestCase
     assert_equal(1, @jar.cookies(url).length)
   end
 
+  def test_cookies_with_leading_dot_match_parent_domains
+    url = URI.parse('http://rubyforge.org/')
+
+    @jar.add(url, cookie_from_hash(cookie_values(:domain => '.rubyforge.org')))
+
+    assert_equal(1, @jar.cookies(url).length)
+  end
+
+  def test_cookies_with_leading_dot_match_parent_domains_exactly
+    url = URI.parse('http://arubyforge.org/')
+
+    @jar.add(url, cookie_from_hash(cookie_values(:domain => '.rubyforge.org')))
+
+    assert_equal(0, @jar.cookies(url).length)
+  end
+
   def test_cookies_dot
     url = URI.parse('http://www.host.example/')
 


### PR DESCRIPTION
Send cookie for '.example.com' on requests for 'example.com' (Issue #136)
