### PR TITLE
Fix for "rake test" generating an encoding error in ruby 1.9.2.

### DIFF
--- a/test/test_mechanize_util.rb
+++ b/test/test_mechanize_util.rb
@@ -69,7 +69,7 @@ class TestMechanizeUtil < MiniTest::Unit::TestCase
   end
 
   def test_from_native_charset_logs_form_when_encoding_error_raised
-    sio = StringIO.new
+    sio = StringIO.new("")
     log = Logger.new(sio)
     log.level = Logger::DEBUG
 
@@ -81,7 +81,7 @@ class TestMechanizeUtil < MiniTest::Unit::TestCase
   end
 
   def test_from_native_charset_logs_form_when_encoding_error_is_ignored
-    sio = StringIO.new
+    sio = StringIO.new("")
     log = Logger.new(sio)
     log.level = Logger::DEBUG
 


### PR DESCRIPTION
rake test in ruby 1.9.2 gives the following error:

```
1) Error:
test_from_native_charset_logs_form_when_encoding_error_raised(TestMechanizeUtil):
ArgumentError: invalid byte sequence in US-ASCII
    /Users/jsc/src/mechanize/test/test_mechanize_util.rb:80:in `test_from_native_charset_logs_form_when_encoding_error_raised'

2) Error:
test_from_native_charset_logs_form_when_encoding_error_is_ignored(TestMechanizeUtil):
ArgumentError: invalid byte sequence in US-ASCII
```

That occurs because StringIO.new when called with no arguments appears
to use whatever the default external encoding is, not the encoding of
the file it is called from. Using StringIO.new("") initializes it with
the encoding of the string it is given, which in this case is UTF-8
because of the "coding" comment at the top.
