### PR TITLE
Fix for content type issue: https://github.com/tenderlove/mechanize/issues/143

### DIFF
--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -357,9 +357,9 @@ class Mechanize::Page < Mechanize::File
       if meta =~ /charset\s*=\s*(["'])?\s*(.+)\s*\1/i then
         $2
       elsif meta =~ /http-equiv\s*=\s*(["'])?content-type\1/i then
-        meta =~ /content=(["'])?(.*?)\1/i
+        meta =~ /content\s*=\s*(["'])?(.*?)\1/i
 
-        m_charset = charset $2
+        m_charset = charset $2 if $2
 
         m_charset if m_charset
       end

--- a/test/test_mechanize_page_encoding.rb
+++ b/test/test_mechanize_page_encoding.rb
@@ -90,6 +90,13 @@ class TestMechanizePageEncoding < MiniTest::Unit::TestCase
     assert_equal [], charsets
   end
 
+  # Test to fix issue: https://github.com/tenderlove/mechanize/issues/143
+  def test_page_meta_charset_handles_whitespace
+    body = '<meta http-equiv = "Content-Type" content = "text/html; charset=iso-8859-1">'
+    charsets = Mechanize::Page.meta_charset(body)
+    assert_equal ["iso-8859-1"], charsets
+  end
+
   def test_meta_charset
     body = '<meta http-equiv="content-type" content="text/html;charset=META">'
     page = util_page body


### PR DESCRIPTION
Whitepsace should be allowed around the equals sign of an HTML
attribute.  In this case the content attribute of the <meta
http-equiv... tag.  Credit goes to Dave Lavin (groovekeeper@gmail.com)
and EG for finding and fixing this issue.
