### PR TITLE
Fix Tempfile issue

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -271,11 +271,21 @@ class Mechanize::HTTP::Agent
 
     hook_content_encoding response, uri, response_body_io
 
+    old_body_io = response_body_io
+
     response_body_io = response_content_encoding response, response_body_io
+
+    # explicitly clean up in case GC misses the tempfile
+    if old_body_io != response_body_io && old_body_io.class == Tempfile
+      old_body_io.close!
+    end
 
     post_connect uri, response, response_body_io
 
     page = response_parse response, response_body_io, uri
+
+    # explicitly clean up in case GC misses the tempfile
+    response_body_io.close! if response_body_io.class == Tempfile
 
     response_cookies response, uri, page
 


### PR DESCRIPTION
I've been encountering an issue with temporary files on several of my machines. Mechanize uses the Tempfile class for several purposes, including handling gzipped files. This class is supposed to remove the temporary file when it is garbage collected, but it seems that this functionality is buggy in certain circumstances, e.g. http://stackoverflow.com/questions/1384373/gc-not-cleaning-up-was-tempfile-not-deleting-automatically-ruby.

The result is that mechanize is leaving behind temporary files when I call agent.get, which accumulate over time. This is occurring on a Linux machine with the specs below but not my Mac.

The fix is to explicitly clean up temporary files in http/agent.rb rather than trusting the garbage collector to handle this when it destroys the Tempfile object. This fix seems to eliminate the issue without affecting any functionality. It would be great if you guys could pull it and test it out so I no longer need a custom gem.

The machine I see this problem on is :
Linux 2.6.35-24-virtual #42-Ubuntu SMP Thu Dec 2 05:15:26 UTC 2010 x86_64 GNU/Linux
ruby 1.8.7 (2010-06-23 patchlevel 299) [x86_64-linux]
