### PR TITLE
Added attr_accessor :filename to Mechanize::Download

### DIFF
--- a/lib/mechanize/download.rb
+++ b/lib/mechanize/download.rb
@@ -10,6 +10,12 @@ class Mechanize::Download
   include Mechanize::Parser
 
   ##
+  # The filename for this file based on the content-disposition of the
+  # response or the basename of the URL
+
+  attr_accessor :filename
+
+  ##
   # Accessor for the IO-like that contains the body
 
   attr_reader :body_io

--- a/test/test_mechanize_download.rb
+++ b/test/test_mechanize_download.rb
@@ -39,5 +39,14 @@ class TestMechanizeDownload < Mechanize::TestCase
     end
   end
 
+  def test_filename
+    uri = URI.parse 'http://example/foo.html'
+    body_io = StringIO.new '0123456789'
+
+    download = @parser.new uri, nil, body_io
+
+    assert_equal "foo.html", download.filename
+  end
+
 end
 

--- a/test/test_mechanize_file.rb
+++ b/test/test_mechanize_file.rb
@@ -57,5 +57,12 @@ class TestMechanizeFile < Mechanize::TestCase
     end
   end
 
+  def test_filename
+    uri = URI 'http://localhost/test.html'
+    page = Mechanize::File.new uri, nil, ''
+
+    assert_equal "test.html", page.filename
+  end
+
 end
 


### PR DESCRIPTION
Mechanize::Download calls extract_filename in it's initialize method
but filename doesn't accessible.
