### PR TITLE
Updated list of supported Ruby versions in the README.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -13,7 +13,7 @@ a history.
 
 == Dependencies
 
-* ruby 1.8.7
+* ruby 1.8.7, 1.9.2, or 1.9.3
 * nokogiri[http://nokogiri.rubyforge.org]
 
 == SUPPORT:


### PR DESCRIPTION
Someone today told me mechanize was 1.8.7 only. I wondered why...
