### PR TITLE
Don't crash on bad Content-Disposition header.

### DIFF
--- a/lib/mechanize/parser.rb
+++ b/lib/mechanize/parser.rb
@@ -113,7 +113,7 @@ module Mechanize::Parser
       content_disposition =
         Mechanize::HTTP::ContentDispositionParser.parse disposition
 
-      if content_disposition then
+      if content_disposition && content_disposition.filename then
         filename = content_disposition.filename
         filename = filename.split(/[\\\/]/).last
         handled = true


### PR DESCRIPTION
It might happen that the Content-Disposition header is present, but
parsing it might yield no filename. This fix takes care of that case.

This happened to me with an ASP.net web application spitting out something like

```
inline; filename*=UTF-8''X%20Y.jpg
```

in this header. I don't think it's useful to "fix" the Content-Disposition parser for this stupid corner case.
