### PR TITLE
NTLM authentication runs in endless loop

### DIFF
--- a/lib/mechanize/http/www_authenticate_parser.rb
+++ b/lib/mechanize/http/www_authenticate_parser.rb
@@ -28,6 +28,11 @@ class Mechanize::HTTP::WWWAuthenticateParser
       challenge = Mechanize::HTTP::AuthChallenge.new
 
       scheme = auth_scheme
+
+      if scheme == 'Negotiate'
+        scan_comma_spaces
+      end
+
       next unless scheme
       challenge.scheme = scheme
 
@@ -80,6 +85,15 @@ class Mechanize::HTTP::WWWAuthenticateParser
 
   def spaces
     @scanner.scan(/ +/)
+  end
+
+  ##
+  # scans a comma followed by spaces
+  # needed for Negotiation, NTLM
+  #
+
+  def scan_comma_spaces
+    @scanner.scan(/, +/)
   end
 
   ##

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -560,7 +560,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
   def test_response_authenticate_ntlm
     @uri += '/ntlm'
     @res.instance_variable_set(:@header,
-                               'www-authenticate' => ['NTLM'])
+                               'www-authenticate' => ['Negotiate, NTLM'])
     @agent.user = 'user'
     @agent.password = 'password'
 


### PR DESCRIPTION
During NTLM  authentication the first challenge comes Bach as www_authenticate = "Negotiation, NTLM".  Without these changes the parser is in an endless loop
