### PR TITLE
NTLM Authentication accepts a domain argument

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -525,10 +525,12 @@ class Mechanize
 
   ##
   # Sets the user and password to be used for HTTP authentication.
+  # sets the optional domain for NTLM authentication
 
-  def auth(user, password)
+  def auth(user, password, domain = nil)
     @agent.user     = user
     @agent.password = password
+    @agent.domain = domain
   end
 
   alias basic_auth auth

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -47,6 +47,7 @@ class Mechanize::HTTP::Agent
   attr_reader :digest_challenges # :nodoc:
   attr_accessor :user
   attr_accessor :password
+  attr_accessor :domain
 
   # :section: Redirection
 
@@ -184,6 +185,7 @@ class Mechanize::HTTP::Agent
     @digest_challenges    = {}
     @password             = nil # HTTP auth password
     @user                 = nil # HTTP auth user
+    @domain               = nil # NTLM HTTP domain
 
     # SSL
     @ca_file         = nil
@@ -697,7 +699,7 @@ class Mechanize::HTTP::Agent
       if challenge.params then
         type_2 = Net::NTLM::Message.decode64 challenge.params
 
-        type_3 = type_2.response({ :user => @user, :password => @password, },
+        type_3 = type_2.response({ :user => @user, :password => @password, :domain => @domain },
                                  { :ntlmv2 => true }).encode64
 
         headers['Authorization'] = "NTLM #{type_3}"

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -557,16 +557,19 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     assert_equal '403 => Net::HTTPForbidden', e.message
   end
 
-  def test_response_authenticate_ntlm
+  def test_response_authenticate_ntlm_
     @uri += '/ntlm'
     @res.instance_variable_set(:@header,
                                'www-authenticate' => ['Negotiate, NTLM'])
     @agent.user = 'user'
     @agent.password = 'password'
+    @agent.domain = 'domain'
 
     page = @agent.response_authenticate @res, nil, @uri, @req, {}, nil, nil
+    
 
     assert_equal 'ok', page.body # lame test
+    
   end
 
   def test_response_authenticate_unknown


### PR DESCRIPTION
Added @domain accessor to the Mechanize class and the agent class and made set it when authenticating with NTLM
