### PR TITLE
Add default of 5 seconds to Mechanize::HTTP::Agent.idle_timeout

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -157,7 +157,7 @@ class Mechanize::HTTP::Agent
     @follow_meta_refresh_self = false
     @gzip_enabled             = true
     @history                  = Mechanize::History.new
-    @idle_timeout             = nil
+    @idle_timeout             = 5
     @keep_alive               = true
     @keep_alive_time          = 300
     @max_file_buffer          = 10240

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -741,10 +741,14 @@ but not <a href="/" rel="me nofollow">this</a>!
     }
   end
 
-  def test_idle_timeout_equals
-    @mech.idle_timeout = 5
+  def test_idle_timeout_default
+    assert_equal 5, Mechanize.new.idle_timeout
+  end
 
-    assert_equal 5, @mech.idle_timeout
+  def test_idle_timeout_equals
+    @mech.idle_timeout = 15
+
+    assert_equal 15, @mech.idle_timeout
   end
 
   def test_keep_alive_equals


### PR DESCRIPTION
I couldn't find the related docs, but here's the patch as discussed in [#ruby-lang](irc://irc.freenode.net/#ruby-lang)

Thanks Eric!
