### PR TITLE
Quoted size parameter in content-disposition raises exception

### DIFF
--- a/lib/mechanize/http/content_disposition_parser.rb
+++ b/lib/mechanize/http/content_disposition_parser.rb
@@ -95,7 +95,7 @@ class Mechanize::HTTP::ContentDispositionParser
               when /^(creation|modification|read)-date$/ then
                 Time.rfc822 rfc_2045_quoted_string
               when /^size$/ then
-                @scanner.scan(/\d+/).to_i(10)
+                rfc_2045_value.to_i(10)
               else
                 rfc_2045_value
               end

--- a/test/test_mechanize_http_content_disposition_parser.rb
+++ b/test/test_mechanize_http_content_disposition_parser.rb
@@ -52,6 +52,12 @@ class TestMechanizeHttpContentDispositionParser < Mechanize::TestCase
     assert_equal 'value',      content_disposition.filename
   end
 
+  def test_parse_quoted_size
+    content_disposition = @parser.parse 'size="5"'
+
+    assert_equal 5, content_disposition.size
+  end
+
   def test_rfc_2045_quoted_string
     @parser.scanner = StringScanner.new '"text"'
 


### PR DESCRIPTION
When trying to crawl [this url](http://mathsyear7.wikispaces.com/file/view/WorldCupMathsProblems.doc) I was getting the following exception:

```
wrong number of arguments(1 for 0)
gems/mechanize-2.3/lib/mechanize/http/content_disposition_parser.rb:98:in `to_i'
gems/mechanize-2.3/lib/mechanize/http/content_disposition_parser.rb:98:in `parse_parameters'
gems/mechanize-2.3/lib/mechanize/http/content_disposition_parser.rb:69:in `parse'
mechanize-2.3/lib/mechanize/http/content_disposition_parser.rb:32:in `parse'
```

The reason being that the size in the content-disposition header was quoted:

```
Content-Disposition: inline; filename="WorldCupMathsProblems.doc"; size="372224"
```

This commit adds a test and a fix for quoted size param.
