### PR TITLE
make sure @authstore key is a URI

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -175,6 +175,7 @@ class Mechanize::HTTP::Agent
   # +domain+ is given it is only used for NTLM authentication.
 
   def add_auth uri, user, password, realm = nil, domain = nil
+    uri = resolve(uri)
     @auth_store.add_auth uri, user, password, realm, domain
   end
 


### PR DESCRIPTION
When checking for credentials, this agent class sends a URI on line 682,
but the @auth_store adds it as as whatever you give it, usually a string.

The @authstore will have the key as a string unless in the Mechanize instance you do:

agent.add_auth( URI.parse(uri),user,pwd))

This change makes sure that the @auth_store key is a URI just like line 682 is expecting
