### PR TITLE
Makes content disposition parameters case insensitive

### DIFF
--- a/lib/mechanize/http/content_disposition_parser.rb
+++ b/lib/mechanize/http/content_disposition_parser.rb
@@ -86,7 +86,7 @@ class Mechanize::HTTP::ContentDispositionParser
 
     while true do
       return nil unless param = rfc_2045_token
-      param.downcase
+      param.downcase!
       return nil unless @scanner.scan(/=/)
 
       value = case param

--- a/test/test_mechanize_http_content_disposition_parser.rb
+++ b/test/test_mechanize_http_content_disposition_parser.rb
@@ -119,6 +119,14 @@ class TestMechanizeHttpContentDispositionParser < Mechanize::TestCase
 
     assert_equal 'end "', string
   end
+  
+  def test_parse_uppercase
+    content_disposition = @parser.parse \
+      'content-disposition: attachment; Filename=value', true
+
+    assert_equal 'attachment', content_disposition.type
+    assert_equal 'value',      content_disposition.filename
+  end
 
 end
 


### PR DESCRIPTION
Currently parameters from the content disposition header are extracted case-sensitively. They should be extracted case-insensitively. 

http://tools.ietf.org/html/rfc6266#section-4.3

Test included!
