### PR TITLE
page already assigned in if conditional, don't need this line.

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -239,8 +239,6 @@ class Mechanize::HTTP::Agent
     end
 
     # Add If-Modified-Since if page is in history
-    page = visited_page(uri)
-
     if (page = visited_page(uri)) and page.response['Last-Modified']
       request['If-Modified-Since'] = page.response['Last-Modified']
     end if(@conditional_requests)


### PR DESCRIPTION
Just spotted this, unless I'm missing something it looks like a duplicated assignment to `page`.
