### PR TITLE
Include application/xml in the content types that trigger the xml parser

### DIFF
--- a/lib/mechanize/pluggable_parsers.rb
+++ b/lib/mechanize/pluggable_parsers.rb
@@ -59,23 +59,23 @@ require 'mechanize/page'
 class Mechanize::PluggableParser
 
   CONTENT_TYPES = {
-    :html  => 'text/html',
-    :wap   => 'application/vnd.wap.xhtml+xml',
-    :xhtml => 'application/xhtml+xml',
-    :pdf   => 'application/pdf',
-    :csv   => 'text/csv',
-    :xml   => 'text/xml',
+    :html  => ['text/html'],
+    :wap   => ['application/vnd.wap.xhtml+xml'],
+    :xhtml => ['application/xhtml+xml'],
+    :pdf   => ['application/pdf'],
+    :csv   => ['text/csv'],
+    :xml   => ['text/xml', 'application/xml'],
   }
 
   attr_accessor :default
 
   def initialize
-    @parsers = {
-      CONTENT_TYPES[:html]  => Mechanize::Page,
-      CONTENT_TYPES[:xhtml] => Mechanize::Page,
-      CONTENT_TYPES[:wap]   => Mechanize::Page,
-      'image'               => Mechanize::Image
-    }
+    @parsers = {}
+
+    register_parser CONTENT_TYPES[:html], Mechanize::Page
+    register_parser CONTENT_TYPES[:xhtml], Mechanize::Page
+    register_parser CONTENT_TYPES[:wap], Mechanize::Page
+    register_parser 'image', Mechanize::Image
 
     @default = Mechanize::File
   end
@@ -100,8 +100,10 @@ class Mechanize::PluggableParser
     default
   end
 
-  def register_parser content_type, klass # :nodoc:
-    @parsers[content_type] = klass
+  def register_parser content_types, klass # :nodoc:
+    [content_types].flatten.each do |content_type|
+      @parsers[content_type] = klass
+    end
   end
 
   ##

--- a/test/test_mechanize_pluggable_parser.rb
+++ b/test/test_mechanize_pluggable_parser.rb
@@ -57,10 +57,12 @@ class TestMechanizePluggableParser < Mechanize::TestCase
 
   def test_xml
     assert_nil @pp['text/xml']
+    assert_nil @pp['application/xml']
 
     @pp.xml = Mechanize::Download
 
     assert_equal Mechanize::Download, @pp['text/xml']
+    assert_equal Mechanize::Download, @pp['application/xml']
   end
 
 end


### PR DESCRIPTION
I noticed responses with a content-type of `application/xml` weren't being treated the same as `text/xml` responses. I've modified pluggable_parsers to treat them the same.

I had to make some minor changes to pluggable_parsers to allow multiple
content types per parser; this is only really necessary to support the
xml= style methods.

See http://stackoverflow.com/a/4832418/27206 for some context on `text/xml` vs. `application/xml`.

Cheers
