### PR TITLE
Fix Mechanize::Form::Field#inspect to read from accessor methods

### DIFF
--- a/lib/mechanize/form/field.rb
+++ b/lib/mechanize/form/field.rb
@@ -54,7 +54,7 @@ class Mechanize::Form::Field
   def inspect # :nodoc:
     "[%s:0x%x type: %s name: %s value: %s]" % [
       self.class.name.sub(/Mechanize::Form::/, '').downcase,
-      object_id, @type, @name, @value
+      object_id, type, name, value
     ]
   end
 

--- a/test/test_mechanize_form_field.rb
+++ b/test/test_mechanize_form_field.rb
@@ -2,6 +2,13 @@ require 'mechanize/test_case'
 
 class TestMechanizeFormField < Mechanize::TestCase
 
+  def test_inspect
+    field = node 'input'
+    field = Mechanize::Form::Field.new field, 'a&b'
+
+    assert_match "value: a&b", field.inspect
+  end
+
   def test_name
     field = node 'input', 'name' => 'a&b'
     field = Mechanize::Form::Field.new field

--- a/test/test_mechanize_form_multi_select_list.rb
+++ b/test/test_mechanize_form_multi_select_list.rb
@@ -22,6 +22,15 @@ class TestMechanizeFormMultiSelectList < Mechanize::TestCase
     @select = form.fields.first
   end
 
+  def test_inspect
+    assert_match "value: 2", @select.inspect
+  end
+
+  def test_inspect_select_all
+    @select.select_all
+    assert_match "value: #{%w[1 2 3 4 5 6]}", @select.inspect
+  end
+
   def test_option_with
     option = @select.option_with :value => '1'
 

--- a/test/test_mechanize_form_option.rb
+++ b/test/test_mechanize_form_option.rb
@@ -20,6 +20,10 @@ class TestMechanizeFormOption < Mechanize::TestCase
     @option2 = @select.options.last
   end
 
+  def test_inspect
+    assert_match "value: 2", @select.inspect
+  end
+
   def test_value_missing_value
     option = node 'option'
     option.inner_html = 'blah'

--- a/test/test_mechanize_form_select_list.rb
+++ b/test/test_mechanize_form_select_list.rb
@@ -22,6 +22,10 @@ class TestMechanizeFormSelectList < Mechanize::TestCase
     @select = form.fields.first
   end
 
+  def test_inspect
+    assert_match "value: 2", @select.inspect
+  end
+
   def test_option_with
     option = @select.option_with :value => '1'
 


### PR DESCRIPTION
This fixes `Mechanize::Form::Field#inspect` to read from accessor methods rather than directly from instance variables.  Without this fix, `#inspect` ends up displaying incorrect attribute values when the accessor methods are overridden by subclasses such as `SelectList`.

For instance in the following test case:

``` html
<form name="form1" method="post" action="/form_post">
  <select name="select">
    <option value="1">Option 1</option>
    <option value="2" selected>Option 2</option>
    <option value="3">Option 3</option>
    <option value="4">Option 4</option>
    <option value="5">Option 5</option>
    <option value="6">Option 6</option>
  </select>
</form>
```
- Before fix: `[selectlist:0x817657d8 type:  name: select value: ]`
- After fix: `[selectlist:0x817657d8 type:  name: select value: 2]`
