### PR TITLE
fix a error on ruby2.0 and using gzip.

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -934,7 +934,7 @@ class Mechanize::HTTP::Agent
     unless Net::HTTP::Head === request or Net::HTTPRedirection === response then
       raise EOFError, "Content-Length (#{content_length}) does not match " \
                       "response body length (#{body_io.length})" if
-        content_length and content_length != body_io.length
+        content_length and content_length != body_io.length and RUBY_VERSION < '2.0.0'
     end
 
     body_io

--- a/lib/mechanize/test_case.rb
+++ b/lib/mechanize/test_case.rb
@@ -257,7 +257,7 @@ class Net::HTTP # :nodoc:
     end
 
     response['Content-Type'] ||= 'text/html'
-    response['Content-Length'] = res['Content-Length'] || res.body.length.to_s
+    response['Content-Length'] = res['Content-Length'] || res.body.bytesize.to_s
 
     io = StringIO.new(res.body)
     response.instance_variable_set :@socket, io

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1299,6 +1299,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
   end
 
   def test_response_read_content_length_mismatch
+    return if RUBY_VERSION >= '2.0.0'
     def @res.content_length() 5 end
     def @res.read_body() yield 'part' end
 


### PR DESCRIPTION
I encounterd an error same as this issue.
https://github.com/sparklemotion/mechanize/issues/275

in ruby2.0, HTTPResponse seems not possible to get original body's length with gzip.
because HTTPResponse inflate automatically now.

so test of content-length checking is skiped in my patch. 

finally, i'm sorry my bad english.
