### PR TITLE
Add header line when writing to cookies.txt

### DIFF
--- a/lib/mechanize/cookie_jar.rb
+++ b/lib/mechanize/cookie_jar.rb
@@ -187,7 +187,7 @@ class Mechanize::CookieJar
 
   # Write cookies to Mozilla cookies.txt-style IO stream
   def dump_cookiestxt(io)
-    io.puts "# Netscape HTTP Cookie File"
+    io.puts "# HTTP Cookie File"
     to_a.each do |cookie|
       io.puts([
         cookie.domain,


### PR DESCRIPTION
When Python is reading a Netscape-format cookies.txt file, it seems to require an initial line that looks like this:

```
# Netscape HTTP Cookie File
```

Mechanize is not writing out a line like that, so Python scripts are unable to read cookie files that were created by Mechanize.  This patch adds that line.

See [this tiny project](https://github.com/mmorearty/mechanize-cookieproblem) for a testable demo.

By the way: I noticed that in #257, the cookie-handling part of Mechanize is in the process of being split off into a separate gem.  So I'll submit another similar pull request on the http-cookie project.
