### PR TITLE
Follow meta refreshes for responses that only contain a refresh meta tag (e.g. t.co responses)

### DIFF
--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -371,7 +371,7 @@ class Mechanize::Page < Mechanize::File
   # Return a list of all meta refresh elements
 
   def meta_refresh
-    query = @mech.follow_meta_refresh == :anywhere ? 'meta' : 'head > meta'
+    query = @mech.follow_meta_refresh == :anywhere || search('head').empty? ? 'meta' : 'head > meta'
 
     @meta_refresh ||= search(query).map do |node|
       MetaRefresh.from_node node, self

--- a/test/htdocs/tc_meta_no_head.html
+++ b/test/htdocs/tc_meta_no_head.html
@@ -1,0 +1,1 @@
+<noscript><meta http-equiv="refresh" content="0; url=http://localhost/index.html"></noscript><script>location.replace("http:\/\/localhost\/index.html")</script>

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -492,6 +492,20 @@ but not <a href="/" rel="me nofollow">this</a>!
     assert_equal('http://example/', @mech.history.last.uri.to_s)
   end
 
+  def test_get_follow_meta_refresh_no_head
+    @mech.follow_meta_refresh = true
+    @mech.follow_meta_refresh_self = true
+
+    page = @mech.get('http://localhost/tc_meta_no_head.html')
+    assert_equal(2, @mech.history.length)
+    assert_equal('http://localhost/tc_meta_no_head.html',
+                 @mech.history[0].uri.to_s)
+    assert_equal('http://localhost/index.html',
+                 @mech.history[1].uri.to_s)
+    assert_equal('http://localhost/index.html', page.uri.to_s)
+    assert_equal('http://localhost/index.html', @mech.history.last.uri.to_s)
+  end
+
   def test_get_follow_meta_refresh_referer_not_sent
     @mech.follow_meta_refresh = true
 


### PR DESCRIPTION
Mechanize currently doesn't follow t.co meta refreshes because they have a response without a `<head>`. For example, the response for [http://t.co/Lizw8srs](http://t.co/Lizw8srs) is simply:

```
<noscript><META http-equiv="refresh" content="0;URL=http://bit.ly/XFwn3X"></noscript><script>location.replace("http:\/\/bit.ly\/XFwn3X")</script>
```

The ['head > meta' selector](https://github.com/sparklemotion/mechanize/blob/master/lib/mechanize/page.rb#L374) doesn't match this, so Mechanize doesn't follow this redirect.

It looks like the original intent of `agent.follow_meta_refresh = :anywhere` was to avoid following meta refreshes outside of `<head>` (see #13 & #99), but this seems to be an entirely different case.

These `<meta>`-only responses are explicit in intent, and fetching t.co URLs is likely a very common need.
