### PR TITLE
Update download.rb

### DIFF
--- a/lib/mechanize/download.rb
+++ b/lib/mechanize/download.rb
@@ -64,6 +64,18 @@ class Mechanize::Download
       end
     end
   end
+  
+  def save! filename = nil
+
+    dirname = File.dirname filename
+    FileUtils.mkdir_p dirname
+
+    open filename, 'wb' do |io|
+      until @body_io.eof? do
+        io.write @body_io.read 16384
+      end
+    end
+  end
 
   alias save_as save
 


### PR DESCRIPTION
added a save! method, which was missing (this method overwrites filenames that already exit.

added this because images cannot utilize the save! method like regular files can.
