### PR TITLE
An empty string as the response content encoding should be treated the same as none/nil.

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -793,7 +793,7 @@ class Mechanize::HTTP::Agent
     return body_io if length.zero?
 
     out_io = case response['Content-Encoding']
-             when nil, 'none', '7bit' then
+             when nil, 'none', '7bit', "" then
                body_io
              when 'deflate' then
                content_encoding_inflate body_io

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1011,6 +1011,14 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     assert_equal 'part', body.read
   end
 
+  def test_response_content_encoding_empty_string
+    @res.instance_variable_set :@header, 'content-encoding' => %w[]
+
+    body = @agent.response_content_encoding @res, StringIO.new('part')
+
+    assert_equal 'part', body.read
+  end
+
   def test_response_content_encoding_tempfile_7_bit
     body_io = tempfile 'part'
 


### PR DESCRIPTION
So the other day, I came across a site that kept resulting in a unsupported content encoding error. Turns out it was returning "" as the content encoding in the response. Any reason empty string shouldn't be treated the same as nil or none? 
