### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -67,9 +67,10 @@ This library comes with a shameless plug for employing me
 
 == Acknowledgments
 
-This library was heavily influenced by its namesake in the perl world.  A big
-thanks goes to Andy Lester (andy@petdance.com), the author of the original
-perl Mechanize which is available here[http://search.cpan.org/~petdance/WWW-Mechanize/].  Ruby Mechanize would not be around without you!
+This library was heavily influenced by its namesake in the Perl world.  A big
+thanks goes to {Andy Lester}[http://petdance.com],
+the author of the original Perl module WWW::Mechanize which is available
+here[http://search.cpan.org/dist/WWW-Mechanize/].  Ruby Mechanize would not be around without you!
 
 Thank you to Michael Neumann for starting the Ruby version.  Thanks to everyone
 who's helped out in various ways.  Finally, thank you to the people using this


### PR DESCRIPTION
Added link to Andy Lester's homepage. Capitalized Perl where appropriate.  Changed the link to the Perl WWW::Mechanize to a permanent URL since Andy Lester no longer maintains it.
