### PR TITLE
Fix form field ordering when backed by Hash nodes

### DIFF
--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -227,6 +227,8 @@ class Mechanize::Form
     query = []
     @mech.log.info("form encoding: #{encoding}") if @mech && @mech.log
 
+    save_hash_field_order
+
     successful_controls = []
 
     (fields + checkboxes).reject do |f|
@@ -274,6 +276,19 @@ class Mechanize::Form
     end
 
     query
+  end
+
+  # This method adds an index to all fields that have Hash nodes. This
+  # enables field sorting to maintain order.
+  def save_hash_field_order
+    index = 0
+
+    fields.each do |field|
+      if Hash === field.node
+        field.index = index
+        index += 1
+      end
+    end
   end
 
   # This method adds a button to the query.  If the form needs to be

--- a/lib/mechanize/form/field.rb
+++ b/lib/mechanize/form/field.rb
@@ -16,6 +16,9 @@
 class Mechanize::Form::Field
   attr_accessor :name, :value, :node, :type
 
+  # index is used to maintain order for fields with Hash nodes
+  attr_accessor :index
+
   def initialize node, value = node['value']
     @node = node
     @name = Mechanize::Util.html_unescape(node['name'])
@@ -34,8 +37,17 @@ class Mechanize::Form::Field
 
   def <=> other
     return 0 if self == other
+
+    # If both are hashes, sort by index
+    if Hash === node && Hash === other.node
+      return index <=> other.index
+    end
+
+    # Otherwise put Hash based fields at the end
     return 1 if Hash === node
     return -1 if Hash === other.node
+
+    # Finally let nokogiri determine sort order
     node <=> other.node
   end
 

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -935,4 +935,32 @@ class TestMechanizeForm < Mechanize::TestCase
     assert_empty page.links
   end
 
+  def test_form_built_from_array_post
+    submitted = @mech.post(
+      'http://example/form_post',
+      [
+        %w[order_matters 0],
+        %w[order_matters 1],
+        %w[order_matters 2],
+        %w[mess_it_up asdf]
+      ]
+    )
+
+    assert_equal 'order_matters=0&order_matters=1&order_matters=2&mess_it_up=asdf', submitted.parser.at('#query').text
+  end
+
+  def test_form_built_from_hashes_submit
+    uri = URI 'http://example/form_post'
+    page = page uri
+    form = Mechanize::Form.new node('form', 'name' => __name__, 'method' => 'POST'), @mech, page
+    form.fields << Mechanize::Form::Field.new({'name' => 'order_matters'}, '0')
+    form.fields << Mechanize::Form::Field.new({'name' => 'order_matters'}, '1')
+    form.fields << Mechanize::Form::Field.new({'name' => 'order_matters'}, '2')
+    form.fields << Mechanize::Form::Field.new({'name' => 'mess_it_up'}, 'asdf')
+
+    submitted = @mech.submit form
+
+    assert_equal 'order_matters=0&order_matters=1&order_matters=2&mess_it_up=asdf', submitted.parser.at('#query').text
+  end
+
 end


### PR DESCRIPTION
When a form field is created with a Hash as the node instead of a
nokogiri node, the sort order was previously undefined.  This can happen
when a user calls `Mechanize.post` or when a Form is manually created
with Hash backed Fields and the user calls `Mechanize.submit` or
`Mechanize::Form#submit`.

fixes #307
