### PR TITLE
Add bang version to #{singular}_with matchers.

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -1293,6 +1293,7 @@ Use of #auth and #basic_auth are deprecated due to a security vulnerability.
 
 end
 
+require 'mechanize/element_not_found_error'
 require 'mechanize/response_read_error'
 require 'mechanize/chunked_termination_error'
 require 'mechanize/content_type_error'

--- a/lib/mechanize/element_matcher.rb
+++ b/lib/mechanize/element_matcher.rb
@@ -28,6 +28,13 @@ module Mechanize::ElementMatcher
         f
       end
 
+      def #{singular}_with! criteria = {}
+        f = #{singular}_with(criteria)
+        raise Mechanize::ElementNotFoundError.new(self, :#{singular}, criteria) if f.nil?
+        yield f if block_given?
+        f
+      end
+
       def select_#{plural} selector
         if selector.nil? then
           #{plural}

--- a/lib/mechanize/element_not_found_error.rb
+++ b/lib/mechanize/element_not_found_error.rb
@@ -1,0 +1,19 @@
+##
+# Raised when an an element was not found on the Page
+
+class Mechanize::ElementNotFoundError < Mechanize::Error
+
+  attr_reader :source
+  attr_reader :element
+  attr_reader :conditions
+
+  def initialize source, element, conditions
+    @source     = source
+    @element    = element 
+    @conditions = conditions
+
+    super "Element #{element} with conditions #{conditions} was not found"
+  end
+  
+end
+

--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -370,6 +370,12 @@ class Mechanize::Form
   #   form.field_with(:id => "exact_field_id").value = 'hello'
 
   ##
+  # :method: field_with!(criteria)
+  #
+  # Same as +field_with+ but raises an ElementNotFoundError if no field matches
+  # +criteria+
+
+  ##
   # :method: fields_with(criteria)
   #
   # Find all fields that match +criteria+
@@ -386,6 +392,12 @@ class Mechanize::Form
   # Find one button that matches +criteria+
   # Example:
   #   form.button_with(:value => /submit/).value = 'hello'
+
+  ##
+  # :method: button_with!(criteria)
+  #
+  # Same as +button_with+ but raises an ElementNotFoundError if no button
+  # matches +criteria+
 
   ##
   # :method: buttons_with(criteria)
@@ -406,6 +418,12 @@ class Mechanize::Form
   #   form.file_upload_with(:file_name => /picture/).value = 'foo'
 
   ##
+  # :mehtod: file_upload_with!(criteria)
+  #
+  # Same as +file_upload_with+ but raises an ElementNotFoundError if no button
+  # matches +criteria+
+
+  ##
   # :method: file_uploads_with(criteria)
   #
   # Find all file upload fields that match +criteria+
@@ -424,6 +442,12 @@ class Mechanize::Form
   #   form.radiobutton_with(:name => /woo/).check
 
   ##
+  # :mehtod: radiobutton_with!(criteria)
+  #
+  # Same as +radiobutton_with+ but raises an ElementNotFoundError if no button
+  # matches +criteria+
+
+  ##
   # :method: radiobuttons_with(criteria)
   #
   # Find all radio buttons that match +criteria+
@@ -440,6 +464,12 @@ class Mechanize::Form
   # Find one checkbox that matches +criteria+
   # Example:
   #   form.checkbox_with(:name => /woo/).check
+
+  ##
+  # :mehtod: checkbox_with!(criteria)
+  #
+  # Same as +checkbox_with+ but raises an ElementNotFoundError if no button
+  # matches +criteria+
 
   ##
   # :method: checkboxes_with(criteria)

--- a/lib/mechanize/form/multi_select_list.rb
+++ b/lib/mechanize/form/multi_select_list.rb
@@ -39,6 +39,12 @@ class Mechanize::Form::MultiSelectList < Mechanize::Form::Field
   #   select_list.option_with(:value => '1').value = 'foo'
 
   ##
+  # :mehtod: option_with!(criteria)
+  #
+  # Same as +option_with+ but raises an ElementNotFoundError if no button
+  # matches +criteria+
+
+  ##
   # :method: options_with
   #
   # Find all options on this select list with +criteria+

--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -224,6 +224,12 @@ class Mechanize::Page < Mechanize::File
   #   end
 
   ##
+  # :mehtod: form_with!(criteria)
+  #
+  # Same as +form_with+ but raises an ElementNotFoundError if no button matches
+  # +criteria+
+
+  ##
   # :method: forms_with
   #
   # :call-seq: forms_with(criteria)
@@ -244,6 +250,12 @@ class Mechanize::Page < Mechanize::File
   # Find a single link matching +criteria+.
   # Example:
   #   page.link_with(:href => /foo/).click
+
+  ##
+  # :mehtod: link_with!(criteria)
+  #
+  # Same as +link_with+ but raises an ElementNotFoundError if no button matches
+  # +criteria+
 
   ##
   # :method: links_with
@@ -269,6 +281,12 @@ class Mechanize::Page < Mechanize::File
   #   page.base_with(:href => /foo/).click
 
   ##
+  # :mehtod: base_with!(criteria)
+  #
+  # Same as +base_with+ but raises an ElementNotFoundError if no button matches
+  # +criteria+
+
+  ##
   # :method: bases_with
   #
   # :call-seq: bases_with(criteria)
@@ -289,6 +307,12 @@ class Mechanize::Page < Mechanize::File
   # Find a single frame tag matching +criteria+.
   # Example:
   #   page.frame_with(:src => /foo/).click
+
+  ##
+  # :mehtod: frame_with!(criteria)
+  #
+  # Same as +frame_with+ but raises an ElementNotFoundError if no button matches
+  # +criteria+
 
   ##
   # :method: frames_with
@@ -313,6 +337,12 @@ class Mechanize::Page < Mechanize::File
   #   page.iframe_with(:src => /foo/).click
 
   ##
+  # :mehtod: iframe_with!(criteria)
+  #
+  # Same as +iframe_with+ but raises an ElementNotFoundError if no button
+  # matches +criteria+
+
+  ##
   # :method: iframes_with
   #
   # :call-seq: iframes_with(criteria)
@@ -333,6 +363,12 @@ class Mechanize::Page < Mechanize::File
   # Find a single image matching +criteria+.
   # Example:
   #   page.image_with(:alt => /main/).fetch.save
+
+  ##
+  # :mehtod: image_with!(criteria)
+  #
+  # Same as +image_with+ but raises an ElementNotFoundError if no button matches
+  # +criteria+
 
   ##
   # :method: images_with

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -1293,6 +1293,14 @@ but not <a href="/" rel="me nofollow">this</a>!
     assert @mech.visited?('http://localhost/response_code?code=302')
   end
 
+  def test_no_frames_exists
+    page = @mech.get("http://localhost/empty_form.html");
+    assert_nil page.frame_with(:name => 'noframe')
+    assert_raises Mechanize::ElementNotFoundError do
+      page.frame_with!(:name => 'noframe')
+    end
+  end
+
   def assert_header(page, header)
     headers = {}
 

--- a/test/test_mechanize_element_not_found_error.rb
+++ b/test/test_mechanize_element_not_found_error.rb
@@ -1,0 +1,15 @@
+require 'mechanize/test_case'
+
+class TestMechanizeRedirectLimitReachedError < Mechanize::TestCase
+
+  def test_to_s
+    page = fake_page
+
+    error = Mechanize::ElementNotFoundError.new(page, :element, :conditions)
+
+    assert_match(/element/, error.to_s)
+    assert_match(/conditions/, error.to_s)
+  end
+
+end
+

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -484,6 +484,13 @@ class TestMechanizeForm < Mechanize::TestCase
     end.submit
   end
 
+  def test_post_with_bang
+    page = @mech.get("http://localhost/form_test.html")
+    page.form_with!(:name => 'post_form1') do |form|
+      form.first_name = 10
+    end.submit
+  end
+
   def test_post
     page = @mech.get("http://localhost/form_test.html")
     post_form = page.forms.find { |f| f.name == "post_form1" }
@@ -891,6 +898,22 @@ class TestMechanizeForm < Mechanize::TestCase
     assert(!form.has_field?('intarweb'))
     assert form.add_field!('intarweb')
     assert(form.has_field?('intarweb'))
+  end
+
+  def test_fill_unexisting_form
+    page = @mech.get("http://localhost/empty_form.html")
+    assert_raises(NoMethodError) {
+      page.form_with(:name => 'no form') { |f| f.foo = 'bar' }
+    }
+    begin
+      page.form_with!(:name => 'no form') { |f| f.foo = 'bar' }
+    rescue => e
+      assert_instance_of Mechanize::ElementNotFoundError, e
+      assert_kind_of Mechanize::Page, e.source
+      assert_equal :form, e.element
+      assert_kind_of Hash, e.conditions
+      assert_equal 'no form', e.conditions[:name]
+    end
   end
 
   def test_field_error

--- a/test/test_mechanize_link.rb
+++ b/test/test_mechanize_link.rb
@@ -12,6 +12,16 @@ class TestMechanizeLink < Mechanize::TestCase
       @mech.history.last.uri.to_s)
   end
 
+  def test_click_bang
+    page = @mech.get("http://localhost/frame_test.html")
+    link = page.link_with!(:text => "Form Test")
+
+    assert_equal('Form Test', link.text)
+    page = link.click
+    assert_equal("http://localhost/form_test.html",
+      @mech.history.last.uri.to_s)
+  end
+
   def test_click_base
     page = @mech.get("http://google.com/tc_base_link.html")
     page = page.links.first.click
@@ -32,6 +42,22 @@ class TestMechanizeLink < Mechanize::TestCase
     link.click
 
     # HACK no assertion
+  end
+
+  def test_click_unexiting_link
+    page = @mech.get("http://google.com/tc_links.html")
+    assert_raises NoMethodError do
+      page.link_with(:text => 'no link').click
+    end
+    begin
+      page.link_with!(:text => 'no link').click
+    rescue => e
+      assert_instance_of Mechanize::ElementNotFoundError, e
+      assert_kind_of Mechanize::Page, e.source
+      assert_equal :link, e.element
+      assert_kind_of Hash, e.conditions
+      assert_equal 'no link', e.conditions[:text]
+    end
   end
 
   def test_click_empty_href


### PR DESCRIPTION
Sometimes you might find that the page you are downloading and working with has
changed. If this is the case then some elements might no longer exists, and you
will start be getting empty lists, nil objects and NoMethodErrors.

This bang version will raise a more according ElementNotFoundError for the
singular version of the element matchers (${singular}_with!), so you can rescue
it and do something to try to notify that the element you are expecting no
longer exists.
