### PR TITLE
Updated for mime-type 2.0.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ hoe = Hoe.spec 'mechanize' do
 
   self.extra_deps << ['net-http-digest_auth', '~> 1.1', '>= 1.1.1']
   self.extra_deps << ['net-http-persistent',  '~> 2.5', '>= 2.5.2']
-  self.extra_deps << ['mime-types',           '~> 1.17', '>= 1.17.2']
+  self.extra_deps << ['mime-types',           '~> 2.0', '>= 2.0']
   self.extra_deps << ['http-cookie',          '~> 1.0.0']
   self.extra_deps << ['nokogiri',             '~> 1.4']
   self.extra_deps << ['ntlm-http',            '~> 0.1', '>= 0.1.1']

--- a/lib/mechanize/pluggable_parsers.rb
+++ b/lib/mechanize/pluggable_parsers.rb
@@ -99,7 +99,7 @@ class Mechanize::PluggableParser
              @parsers[mime_type.simplified] ||
              @parsers[mime_type.media_type] ||
              default
-  rescue MIME::InvalidContentType
+  rescue MIME::Type::InvalidContentType
     default
   end
 


### PR DESCRIPTION
The extra dependency of mime-types has been updated to use the 2.0 version of that gem. This is largely because many test frameworks that might incorporate Mechanize (like Cucumber) use mime-types 2.0. What would happen is that errors like this would occur:

Unable to activate mechanize-2.7.2, because mime-types-2.0 conflicts with mime-types (>= 1.17.2, ~> 1.17) (Gem::LoadError)

Also, even with the previous mime-type a deprecated usage of MIME::InvalidContentType was being used. I updated that to MIME::Type::InvalidContentType.
