### PR TITLE
Allow a Form::FileUpload to be passed in as a query value to #post

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -495,6 +495,9 @@ class Mechanize
         ul = Form::FileUpload.new({'name' => k.to_s},::File.basename(v.path))
         ul.file_data = v.read
         form.file_uploads << ul
+      elsif v.is_a?(Form::FileUpload)
+        form.enctype = 'multipart/form-data'
+        form.file_uploads << v
       else
         form.fields << Form::Field.new({'name' => k.to_s},v)
       end

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -942,6 +942,25 @@ but not <a href="/" rel="me nofollow">this</a>!
     assert page.body.length > File.read(__FILE__).length
   end
 
+  def test_post_file_upload
+    name = File.basename(__FILE__)
+    file_upload = Mechanize::Form::FileUpload.new({'name' => 'userfile1'}, name)
+    file_upload.file_data = File.read(__FILE__)
+    file_upload.mime_type = 'application/zip'
+
+    page = @mech.post('http://localhost/file_upload', {
+      :name       => 'Some file',
+      :userfile1  => file_upload
+    })
+
+    assert_match(
+      "Content-Disposition: form-data; name=\"userfile1\"; filename=\"#{name}\"",
+      page.body
+    )
+    assert_match("Content-Type: application/zip", page.body)
+    assert page.body.length > File.read(__FILE__).length
+  end
+
   def test_post_redirect
     page = @mech.post('http://localhost/redirect')
 


### PR DESCRIPTION
If an IO-like object is passed in as a query value to `Mechanize#post`, then Mechanize [will build a Form::FileUpload object for you](https://github.com/sparklemotion/mechanize/blob/master/lib/mechanize.rb#L493), and add it to the `form.file_uploads`. This is very convenient, except when you want to specify the `#mime_type` on said Form::FileUpload.

This patch allows the user to build their own `Form::FileUpload`, and pass that in as a query value.

Test included.
