### PR TITLE
Expose the resolve functionality of http/agent on mechanize.

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -938,6 +938,12 @@ Use of #auth and #basic_auth are deprecated due to a security vulnerability.
   end
 
   ##
+  # Resolve the full path of a link / uri
+  def resolve link
+    @agent.resolve link
+  end
+
+  ##
   # A hash of custom request headers that will be sent on every request
 
   def request_headers

--- a/lib/mechanize/page/link.rb
+++ b/lib/mechanize/page/link.rb
@@ -99,5 +99,10 @@ class Mechanize::Page::Link
              end
   end
 
+  # A fully resolved URI for the #href for this link.
+  def resolved_uri
+    @mech.resolve uri
+  end
+
 end
 

--- a/test/test_mechanize_link.rb
+++ b/test/test_mechanize_link.rb
@@ -110,5 +110,12 @@ class TestMechanizeLink < Mechanize::TestCase
     assert_equal 'http://foo.bar/%20baz', link.uri.to_s
   end
 
+  def test_resolving_full_uri
+    page = @mech.get("http://localhost/frame_test.html")
+    link = page.link_with(:text => "Form Test")
+
+    assert_equal "/form_test.html", link.uri.to_s
+    assert_equal "http://localhost/form_test.html", link.resolved_uri.to_s
+  end
 end
 


### PR DESCRIPTION
Expose `http/agent#resolve` as `mechanize#resolve` and use to provide
`page/link#resolved_uri`, sometimes it's nice to have access to the full
url from outside of mechanize.
