### PR TITLE
change links to GUIDE AND EXAMPLES to github links

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,8 +28,8 @@ The bug tracker is available here:
 
 == Examples
 
-If you are just starting, check out the GUIDE[http://mechanize.rubyforge.org/GUIDE_rdoc.html] or
-the EXAMPLES[http://mechanize.rubyforge.org/EXAMPLES_rdoc.html] file.
+If you are just starting, check out the GUIDE[https://github.com/sparklemotion/mechanize/blob/master/GUIDE.rdoc] or
+the EXAMPLES[https://github.com/sparklemotion/mechanize/blob/master/EXAMPLES.rdoc] file.
 
 == Developers
 


### PR DESCRIPTION
In reference to https://github.com/sparklemotion/mechanize/issues/355
