### PR TITLE
Fix obfuscation of error in handling invalid gzip responses.

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -822,7 +822,7 @@ class Mechanize::HTTP::Agent
   ensure
     begin
       if Tempfile === body_io and
-         (StringIO === out_io or out_io.path != body_io.path) then
+         (StringIO === out_io or (out_io and out_io.path != body_io.path)) then
         body_io.close!
       end
     rescue IOError


### PR DESCRIPTION
I have a gzip response that invalidly reports a `NoMethodError` due to the
`ensure` clause attempting to compare path of nil with the body. This protects
against this by not attempting to close body if we don't have an output.

For reference the error is a `Zlib::BufError` being raised thusly:

```
/lib/mechanize/http/agent.rb:1181:in `finish'
/lib/mechanize/http/agent.rb:1181:in `inflate'
/lib/mechanize/http/agent.rb:439:in `rescue in content_encoding_gunzip'
/lib/mechanize/http/agent.rb:448:in `content_encoding_gunzip'
/lib/mechanize/http/agent.rb:814:in `response_content_encoding'
/lib/mechanize/http/agent.rb:275:in `fetch'
/lib/mechanize.rb:440:in `get'
```
