### PR TITLE
Add Page::Image#uri as an alias of #url

### DIFF
--- a/lib/mechanize/page/image.rb
+++ b/lib/mechanize/page/image.rb
@@ -169,6 +169,8 @@ class Mechanize::Page::Image
     end
   end
 
+  alias uri url
+
   ##
   # The width attribute of the image
 


### PR DESCRIPTION
Page::Image class has a method #url, but other methods returns URI are named #uri (eg. Page::Link#uri, FileResponse#uri).
This pull request defines Image#uri as an alias of #url.
