### PR TITLE
make sure the username / password is stripped from the URL

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -519,6 +519,8 @@ class Mechanize::HTTP::Agent
 
   def request_auth request, uri
     base_uri = uri + '/'
+    base_uri.user     = nil
+    base_uri.password = nil
     schemes = @authenticate_methods[base_uri]
 
     if realm = schemes[:digest].find { |r| r.uri == base_uri } then

--- a/lib/mechanize/http/auth_store.rb
+++ b/lib/mechanize/http/auth_store.rb
@@ -93,6 +93,8 @@ only to a particular server you specify.
     uri = URI uri unless URI === uri
 
     uri += '/'
+    uri.user = nil
+    uri.password = nil
 
     realms = @auth_accounts[uri]
 

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -492,6 +492,12 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     assert_match %r%^Digest %, @req['Authorization']
     assert_match %r%qop=auth%, @req['Authorization']
+
+    @req['Authorization'] = nil
+    @agent.request_auth @req, @uri
+
+    assert_match %r%^Digest %, @req['Authorization']
+    assert_match %r%qop=auth%, @req['Authorization']
   end
 
   def test_request_auth_iis_digest


### PR DESCRIPTION
I was having the following issue with mechanize when using digest auth:

The first request to a website containing a form would succeed, but submitting the form then would fail with a 401:

```
Mechanize::UnauthorizedError: 401 => Net::HTTPUnauthorized for https://username:password@test.com/entry/? -- no credentials found, provide some with #add_auth -- available realms: App Zone
```

The thing to note is that the URI for subsequent requests contained the username/password as set by add_auth to mechanize. It uses this URI (the one including username/password) to lookup the credentials for the next request, and fail as no credentials are registered for that URI.

So I've made this patch to strip out the username / password from the URI before looking up the credentials.
