### PR TITLE
Update EXAMPLES.rdoc to fix Google example

### DIFF
--- a/EXAMPLES.rdoc
+++ b/EXAMPLES.rdoc
@@ -15,7 +15,7 @@ example, <code>do ... end.submit</code> is the same as <code>{ ...
   }
 
   a.get('http://google.com/') do |page|
-    search_result = page.form_with(:name => 'gbqf') do |search|
+    search_result = page.form_with(:id => 'gbqf') do |search|
       search.q = 'Hello world'
     end.submit
 


### PR DESCRIPTION
Very strange that it was only when I changed the key to :id that it worked and did a "pp a", otherwise copying the code and running it initially gave a "<main>': undefined method `q=' for nil:NilClass (NoMethodError)"

Changed page.form_with(:name => 'gbqf') to page.form_with(:id => 'gbqf')

This could also have educational benefits as no example in the document uses the ID key as a parameter.
