### PR TITLE
Making sure ALL test files are ran, not just the first one!

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'rubygems'
 require "bundler/gem_tasks"
 
 require 'rdoc/task'
+require 'rake/testtask'
 
 task :prerelease => [:clobber_rdoc, :test]
 
@@ -24,6 +25,9 @@ RDoc::Task.new do |rdoc|
 end
 
 desc "Run tests"
-task "test" do
-  ruby "-I'lib:test' " + FileList['test/**/test*.rb'].join(' ')
-end
+task :test do |x|
+  Rake::TestTask.new { |t|
+    t.test_files = Dir['test/**/test*.rb']
+    t.verbose = true
+  }
+end # :test


### PR DESCRIPTION
Fixes Issue #398

**Please note that it fails CI checks because it now runs ALL of the tests (that weren't run previously) — and one of _your_ tests fails!**
