### PR TITLE
Adding capability to @agent.click() on an explicit button.

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -349,12 +349,21 @@ class Mechanize
         click real_link
       else
         button = nil
+        # Note that this will not work if we have since navigated to a different page.
+        # Should rather make each button aware of its parent form.
         form = page.forms.find do |f|
           button = f.button_with(:value => link)
           button.is_a? Form::Submit
         end
         submit form, button if form
       end
+    when Form::Submit, Form::ImageButton then
+      # Note that this will not work if we have since navigated to a different page.
+      # Should rather make each button aware of its parent form.
+      form = page.forms.find do |f|
+        f.buttons.include?(link)
+      end
+      submit form, link if form
     else
       referer = current_page()
       href = link.respond_to?(:href) ? link.href :

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -106,6 +106,22 @@ class TestMechanize < Mechanize::TestCase
     assert_equal '/index.html', requests.first.path
   end
 
+  def test_click_image_button
+    page = @mech.get("http://localhost/form_test.html")
+    get_form = page.forms.find { |f| f.name == "get_form1" }
+    image_button = get_form.buttons.first
+    new_page = @mech.click(image_button)
+    assert_equal "http://localhost/form_post?first_name=&button.x=0&button.y=0", new_page.uri.to_s
+  end
+
+  def test_click_submit_button
+    page = @mech.get("http://localhost/form_test.html")
+    get_form = page.forms.find { |f| f.name == "get_form1" }
+    submit_button = get_form.submits.first
+    new_page = @mech.click(submit_button)
+    assert_equal "http://localhost/form_post?first_name=", new_page.uri.to_s
+  end
+
   def test_click_frame
     frame = node 'frame', 'src' => '/index.html'
     frame = Mechanize::Page::Frame.new frame, @mech, fake_page


### PR DESCRIPTION
Image-buttons are oftentimes not given names, so it is not possible to utilize "search by value" functionality provided by click() for them.
