### PR TITLE
Pass uri information to Nokogiri if available.

### DIFF
--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -113,13 +113,19 @@ class Mechanize::Page < Mechanize::File
     return @parser if @parser
     return nil unless @body
 
+    if @uri.nil?
+      uri_string = nil
+    else
+      uri_string = @uri.to_s
+    end
+
     if @encoding then
-      @parser = @mech.html_parser.parse html_body, nil, @encoding
+      @parser = @mech.html_parser.parse html_body, uri_string, @encoding
     elsif mech.force_default_encoding then
-      @parser = @mech.html_parser.parse html_body, nil, @mech.default_encoding
+      @parser = @mech.html_parser.parse html_body, uri_string, @mech.default_encoding
     else
       @encodings.reverse_each do |encoding|
-        @parser = @mech.html_parser.parse html_body, nil, encoding
+        @parser = @mech.html_parser.parse html_body, uri_string, encoding
 
         break unless encoding_error? @parser
       end


### PR DESCRIPTION
Currently when creating Nokogiri parser, the url is not passed to its initialize method.
I have some special needs for url in the Nokogiri object.
I am not sure if it was intentional to pass nil, however tests did pass.