### PR TITLE
Remove deprecated rubyforge_project attribute

### DIFF
--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
       'ljjarvis@gmail.com'
     ]
 
-  spec.rubyforge_project = "mechanize"
   spec.license           = "MIT"
 
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Not a big whoop but hey, little things.