### PR TITLE
Prevent malformed WWW-Authenticate headers from causing infinite loops

### DIFF
--- a/lib/mechanize/http/www_authenticate_parser.rb
+++ b/lib/mechanize/http/www_authenticate_parser.rb
@@ -34,7 +34,7 @@ class Mechanize::HTTP::WWWAuthenticateParser
         scan_comma_spaces
       end
 
-      next unless scheme
+      break unless scheme
       challenge.scheme = scheme
 
       space = spaces

--- a/test/test_mechanize_http_www_authenticate_parser.rb
+++ b/test/test_mechanize_http_www_authenticate_parser.rb
@@ -133,6 +133,14 @@ class TestMechanizeHttpWwwAuthenticateParser < Mechanize::TestCase
     assert_equal expected, @parser.parse('Basic realm = "foo"')
   end
 
+  def test_parse_bad_single_quote
+    expected = [
+      challenge('Basic', { 'realm' => "'foo" }, "Basic realm='foo"),
+    ]
+
+    assert_equal expected, @parser.parse("Basic realm='foo bar', qop='baz'")
+  end
+
   def test_quoted_string
     @parser.scanner = StringScanner.new '"text"'
 


### PR DESCRIPTION
As reported in #441, the `Mechanize::HTTP::WWWAuthenticateParser` parser gets stuck in a loop
in some cases when the WWW-Authenticate header is malformed.

The string scanner will continue to loop if it has not reached the end of the header string AND if the remainder of the string does not contain a recognisable auth-scheme.

This PR changes the behaviour such that it  will break out of the loop if the remaining header string is not recognisable (rather than getting stuck in a loop).
