### PR TITLE
Added code to prevent empty query params from being sent over in a build_query

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -1299,6 +1299,13 @@ Use of #auth and #basic_auth are deprecated due to a security vulnerability.
     @agent.shutdown
   end
 
+  ##
+  # Allow Query Parameter values to be empty
+
+  def allow_empty_query_values allow_empty
+    @agent.allow_empty_query_values = allow_empty
+  end
+
   private
 
   ##

--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -264,8 +264,16 @@ class Mechanize::Form
         if f.checked
           successful_controls << f
         end
-      when Mechanize::Form::Field
-        successful_controls << f
+        when Mechanize::Form::Field
+          if @mech.nil? || @mech.agent.allow_empty_query_values
+            successful_controls << f
+          else
+            if f.kind_of?(Mechanize::Form::Text)
+              successful_controls << f if f.value != ''
+            else
+              successful_controls << f
+            end
+          end
       end
     end
 

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -117,6 +117,9 @@ class Mechanize::HTTP::Agent
   # enabling this as it may cause data loss.
   attr_accessor :ignore_bad_chunking
 
+  # Prevents empty query string values from being included
+  attr_accessor :allow_empty_query_values
+
   # Handlers for various URI schemes
   attr_accessor :scheme_handlers
 
@@ -150,6 +153,7 @@ class Mechanize::HTTP::Agent
     @robots                   = false
     @user_agent               = nil
     @webrobots                = nil
+    @allow_empty_query_values = true
 
     # HTTP Authentication
     @auth_store           = Mechanize::HTTP::AuthStore.new

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -1005,4 +1005,22 @@ class TestMechanizeForm < Mechanize::TestCase
     assert_equal 'order_matters=0&order_matters=1&order_matters=2&mess_it_up=asdf', submitted.parser.at('#query').text
   end
 
+  def test_prevent_empty_query_params
+    page = @mech.get("http://localhost/form_test.html")
+    @mech.agent.allow_empty_query_values = false
+    get_form = page.forms.find { |f| f.name == "get_form1" }
+    image_button = get_form.buttons.first
+    new_page = @mech.click(image_button)
+    assert_equal "http://localhost/form_post?button.x=0&button.y=0", new_page.uri.to_s
+  end
+
+  def test_allow_empty_query_params
+    page = @mech.get("http://localhost/form_test.html")
+    @mech.agent.allow_empty_query_values = true
+    get_form = page.forms.find { |f| f.name == "get_form1" }
+    image_button = get_form.buttons.first
+    new_page = @mech.click(image_button)
+    assert_equal "http://localhost/form_post?first_name=&button.x=0&button.y=0", new_page.uri.to_s
+  end
+
 end


### PR DESCRIPTION
Based on an issue where the browser has identified that the empty value in the request should not be sent. This feature allows empty values to be suppressed and not included in the build query. Tests were added and the default behaviour has not changed. allow_empty_query_values is now a new property of the agent and should be set to false to prevent empty values.

I've added a property to the agent allow_empty_query_values and defaulted it to true, so it will behave as it does already. When it's specifically switched off then empty values in the build query are removed.

I'm still a little unclear how the browser and mechanize have acted differently on this occasion, but it would seem that a feature to prevent mechanize from including empty values gives greater power of the request.

BTW: this is my first pull request so comments would be most welcome? I've also added a couple of tests.
