### PR TITLE
File upload equivalents of Form#add_field! and Form#delete_field!

### DIFF
--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -153,6 +153,15 @@ class Mechanize::Form
     fields << Field.new({'name' => field_name}, value)
   end
 
+  # Add a file upload with +field_name+ and a file named +file_name+, with
+  # contents +file_data+, and MIME type +mime_type.
+  def add_file_upload!(field_name, file_name, file_data = nil, mime_type = nil)
+    upload = FileUpload.new({'name' => field_name }, file_name)
+    upload.file_data = file_data
+    upload.mime_type = mime_type
+    file_uploads << upload
+  end
+
   ##
   # This method sets multiple fields on the form.  It takes a list of +fields+
   # which are name, value pairs.
@@ -365,7 +374,12 @@ class Mechanize::Form
 
   # Removes all fields with name +field_name+.
   def delete_field!(field_name)
-    @fields.delete_if{ |f| f.name == field_name}
+    @fields.delete_if { |f| f.name == field_name}
+  end
+
+  # Removes all file upload fields with name +field_name+.
+  def delete_file_upload!(field_name)
+    @file_uploads.delete_if { |f| f.name == field_name}
   end
 
   ##

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -919,6 +919,34 @@ class TestMechanizeForm < Mechanize::TestCase
     assert(form.has_field?('intarweb'))
   end
 
+  def test_add_file_upload
+    page = @mech.get("http://localhost/file_upload.html")
+    form = page.form_with(:name => 'value_test')
+
+    number_of_uploads = form.file_uploads.length
+
+    assert form.add_file_upload!('ham', '/etc/passwd', 'ohnoes', 'text/plain')
+    assert_equal(number_of_uploads + 1, form.file_uploads.length)
+
+    upload = form.file_upload_with(:name => 'ham')
+    assert upload
+    assert_equal '/etc/passwd', upload.file_name
+    assert_equal 'ohnoes', upload.file_data
+    assert_equal 'text/plain', upload.mime_type
+  end
+
+  def test_delete_file_upload
+    page = @mech.get("http://localhost/file_upload.html")
+    form = page.form_with(:name => 'value_test')
+
+    number_of_uploads = form.file_uploads.length
+    assert_equal 1, number_of_uploads
+
+    form.delete_file_upload!('green[eggs]')
+    assert_nil(form.file_upload_with(:name => 'green[eggs]'))
+    assert_equal(number_of_uploads - 1, form.file_uploads.length)
+  end
+
   def test_fill_unexisting_form
     page = @mech.get("http://localhost/empty_form.html")
     assert_raises(NoMethodError) {


### PR DESCRIPTION
I found `Form#add_field!` very convenient for dealing with forms that use a bit of XHR to create new fields. This change adds `Form#add_file_upload!`, so I can use the same trick for `<input type="file">` fields, which are their own special beasts.

While I was at it, I added `Form#delete_file_upload!`, because I figured it'd keep things symmetric.

Thank you for maintaining this great gem! :heart: 
