### PR TITLE
As reported in #450, WWW-Authenticate with whitespace result in loop

### DIFF
--- a/lib/mechanize/http/www_authenticate_parser.rb
+++ b/lib/mechanize/http/www_authenticate_parser.rb
@@ -128,7 +128,7 @@ class Mechanize::HTTP::WWWAuthenticateParser
 
   def auth_param
     return nil unless name = token
-    return nil unless @scanner.scan(/=/)
+    return nil unless @scanner.scan(/ *= */)
 
     value = if @scanner.peek(1) == '"' then
               quoted_string

--- a/test/test_mechanize_http_www_authenticate_parser.rb
+++ b/test/test_mechanize_http_www_authenticate_parser.rb
@@ -117,6 +117,14 @@ class TestMechanizeHttpWwwAuthenticateParser < Mechanize::TestCase
     assert_equal expected, @parser.parse('BaSiC realm=foo')
   end
 
+  def test_parse_bad_whitespace_around_auth_param
+    expected = [
+      challenge('Basic', { 'realm' => 'foo' }, 'Basic realm = "foo"'),
+    ]
+
+    assert_equal expected, @parser.parse('Basic realm = "foo"')
+  end
+
   def test_quoted_string
     @parser.scanner = StringScanner.new '"text"'
 


### PR DESCRIPTION
As reported in #450, a bad formated WWW-Authenticate with whitespace result in loop.

Simple Basic auth, whitespace used in auth-param assignment, see testcase
http://greenbytes.de/tech/tc/httpauth/#simplebasicwsrealm
All current browsers pass the case as valid and so should mechanize.