### PR TITLE
Don't allow redirect from a non-file URL to a file URL for security reasons

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -19,6 +19,7 @@
 * Bug fix
   * Don't raise an exception if a connection has set a {read,open}_timeout and
     a `file://` request is made. (#397)
+  * Don't allow redirect from a non-file URL to a file URL for security reasons.
 
 === 2.7.3
 

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -19,7 +19,7 @@
 * Bug fix
   * Don't raise an exception if a connection has set a {read,open}_timeout and
     a `file://` request is made. (#397)
-  * Don't allow redirect from a non-file URL to a file URL for security reasons.
+  * Don't allow redirect from a non-file URL to a file URL for security reasons. (#455)
 
 === 2.7.3
 

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -677,6 +677,18 @@ class Mechanize::HTTP::Agent
     uri
   end
 
+  def secure_resolve!(uri, referer = current_page)
+    new_uri = resolve(uri, referer)
+
+    if (referer_uri = referer && referer.uri) &&
+       referer_uri.scheme != 'file'.freeze &&
+       new_uri.scheme == 'file'.freeze
+      raise Mechanize::Error, "insecure redirect to a file URI"
+    end
+
+    new_uri
+  end
+
   def resolve_parameters uri, method, parameters
     case method
     when :head, :get, :delete, :trace then
@@ -859,7 +871,7 @@ class Mechanize::HTTP::Agent
   def response_follow_meta_refresh response, uri, page, redirects
     delay, new_url = get_meta_refresh(response, uri, page)
     return nil unless delay
-    new_url = new_url ? resolve(new_url, page) : uri
+    new_url = new_url ? secure_resolve!(new_url, page) : uri
 
     raise Mechanize::RedirectLimitReachedError.new(page, redirects) if
       redirects + 1 > @redirection_limit
@@ -967,8 +979,9 @@ class Mechanize::HTTP::Agent
       headers.delete key
     end
 
+    new_uri = secure_resolve! response['Location'].to_s, page
+
     @history.push(page, page.uri)
-    new_uri = resolve response['Location'].to_s, page
 
     fetch new_uri, redirect_method, headers, [], referer, redirects + 1
   end


### PR DESCRIPTION
Redirect to a file URL may make it easier for remote attackers to obtain sensitive information or cause a DoS.

/cc @leejarvis