### PR TITLE
Enable support for mime-types 3

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,23 +4,41 @@
 
 * New Features
   * Accept array-like and hash-like values as query/parameter value.
-    A new utility method Mechanize::Util.each_parameter is added, and Mechanize::Util.build_query_string is enhanced
-    for this feature.
-  * Allow passing a `Form::FileUpload` instance to `#post`. #350 by Sam
+    A new utility method Mechanize::Util.each_parameter is added, and
+    Mechanize::Util.build_query_string is enhanced for this feature.
+  * Allow passing a +Form::FileUpload+ instance to <tt>#post</tt>. #350 by Sam
     Rawlins.
   * Capture link when scheme is unsupported. #362 by Jon Rowe.
-  * Pre-defined User-Agent stings are updated to those of more recent versions, and new aliases for IE 10/11 are added.
-  * Support for mime-types 1.x is restored while keeping compatible with mime-types 2.x.
+  * Pre-defined User-Agent stings are updated to those of more recent versions,
+    and new aliases for IE 10/11 are added.
+  * Support for mime-types 1.x is restored while keeping compatible with
+    mime-types 2 and higher.
+  * Added support for mime-types 3.x. Support for mime-types 3.x has two
+    effects:
+
+    * For types that were previously considered experimental (e.g.,
+      <tt>text/x-csv</tt>) type simplification no longer removes the
+      <tt>x-</tt> prefix per {RFC 6648}[http://tools.ietf.org/html/rfc6648].
+      Types of this form that had previously registered parsers automatically
+      assigned through this change should now be explicitly registered:
+
+	 mechanize.pluggable_parser.register_parser 'image/x-png',
+	   Mechanize::Image
+
+    * For users that *require* Ruby 1.9 support, your Gemfile must restrict
+      mime-types to <tt>< 3.0</tt>. mime-types 3 requires Ruby 2.0 or higher.
+
   * Mechanize::Page now responds to #xpath, #css, #at_xpath, #at_css, and #%.
-  * element(s)_with methods now accept :xpath and :css options for doing xpath/css
-    selector searching.
+  * element(s)_with methods now accept :xpath and :css options for doing
+    xpath/css selector searching.
   * Pass URI information to Nokogiri where applicable. #405 @lulalala
 
 * Bug fix
   * Don't raise an exception if a connection has set a {read,open}_timeout and
     a `file://` request is made. (#397)
   * Fix whitespace bug in WWW-Authenticate. #451, #450, by Rasmus Bergholdt
-  * Don't allow redirect from a non-file URL to a file URL for security reasons. (#455)
+  * Don't allow redirect from a non-file URL to a file URL for security
+    reasons. (#455)
 
 === 2.7.3
 

--- a/lib/mechanize/pluggable_parsers.rb
+++ b/lib/mechanize/pluggable_parsers.rb
@@ -2,7 +2,13 @@ require 'mechanize/file'
 require 'mechanize/file_saver'
 require 'mechanize/page'
 require 'mechanize/xml_file'
-require 'mime/types'
+
+begin
+  # Take advantage of the lower-memory mode available from mime-types >= 2.6.
+  require 'mime/types/columnar'
+rescue LoadError
+  require 'mime/types'
+end
 
 ##
 # Mechanize allows different parsers for different content types.  Mechanize

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "net-http-digest_auth", [ ">= 1.1.1", "~> 1.1" ]
   spec.add_runtime_dependency "net-http-persistent",  [ ">= 2.5.2", "~> 2.5" ]
-  spec.add_runtime_dependency "mime-types",           [ ">= 1.17.2", "< 3" ]
+  spec.add_runtime_dependency "mime-types",           [ ">= 1.17.2", "< 4" ]
   spec.add_runtime_dependency "http-cookie",          [ "~> 1.0" ]
   spec.add_runtime_dependency "nokogiri",             [ "~> 1.6" ]
   spec.add_runtime_dependency "ntlm-http",            [ ">= 0.1.1", "~> 0.1"   ]

--- a/test/test_mechanize_pluggable_parser.rb
+++ b/test/test_mechanize_pluggable_parser.rb
@@ -36,7 +36,16 @@ class TestMechanizePluggableParser < Mechanize::TestCase
   def test_parser_mime
     @pp['image/png'] = :png
 
-    assert_equal :png, @pp.parser('x-image/x-png')
+    if Gem::Version.new(MIME::Types::VERSION) < Gem::Version.new('3.0')
+      # This is no longer true under mime-types 3 because the x- prefix has
+      # been deprecated by IANA. It is no longer safe to say that x-png and png
+      # are the same.
+      assert_equal :png, @pp.parser('x-image/x-png')
+    else
+      assert_equal Mechanize::File, @pp.parser('x-image/x-png')
+      @pp['x-image/x-png'] = :png
+      assert_equal :png, @pp.parser('x-image/x-png')
+    end
     assert_equal :png, @pp.parser('image/png')
     assert_equal Mechanize::Image, @pp.parser('image')
   end


### PR DESCRIPTION
mime-types 3 is mostly compatible with the way that Mechanize uses mime-types,
but I have expanded the details of two minor incompatibilities in the
Changelog.
