### PR TITLE
Fix issue #458: Basic authentication fails when specifying credentials for a realm that contains uppercase characters

### DIFF
--- a/lib/mechanize/http/auth_realm.rb
+++ b/lib/mechanize/http/auth_realm.rb
@@ -7,7 +7,7 @@ class Mechanize::HTTP::AuthRealm
   def initialize scheme, uri, realm
     @scheme = scheme
     @uri    = uri
-    @realm  = realm.downcase if realm
+    @realm  = realm if realm
   end
 
   def == other

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -374,6 +374,14 @@ but not <a href="/" rel="me nofollow">this</a>!
     end
   end
 
+  def test_get_auth
+    @mech.add_auth @uri, 'user', 'pass'
+
+    page = @mech.get @uri + '/basic_auth'
+
+    assert_equal 'You are authenticated', page.body
+  end
+
   def test_get_auth_bad
     @mech.add_auth(@uri, 'aaron', 'aaron')
 
@@ -390,6 +398,14 @@ but not <a href="/" rel="me nofollow">this</a>!
     end
 
     assert_equal("401", e.response_code)
+  end
+
+  def test_get_auth_realm
+    @mech.add_auth @uri, 'user', 'pass', 'Blah'
+
+    page = @mech.get @uri + '/basic_auth'
+
+    assert_equal 'You are authenticated', page.body
   end
 
   def test_get_conditional

--- a/test/test_mechanize_http_auth_challenge.rb
+++ b/test/test_mechanize_http_auth_challenge.rb
@@ -25,6 +25,14 @@ class TestMechanizeHttpAuthChallenge < Mechanize::TestCase
     assert_equal expected, @challenge.realm(@uri + '/foo')
   end
 
+  def test_realm_digest_case
+    challenge = @AC.new 'Digest', { 'realm' => 'R' }, 'Digest realm=R'
+
+    expected = @AR.new 'Digest', @uri, 'R'
+
+    assert_equal expected, challenge.realm(@uri + '/foo')
+  end
+
   def test_realm_unknown
     @challenge.scheme = 'Unknown'
 
@@ -37,6 +45,12 @@ class TestMechanizeHttpAuthChallenge < Mechanize::TestCase
 
   def test_realm_name
     assert_equal 'r', @challenge.realm_name
+  end
+
+  def test_realm_name_case
+    challenge = @AC.new 'Digest', { 'realm' => 'R' }, 'Digest realm=R'
+
+    assert_equal 'R', challenge.realm_name
   end
 
   def test_realm_name_ntlm

--- a/test/test_mechanize_http_auth_realm.rb
+++ b/test/test_mechanize_http_auth_realm.rb
@@ -14,7 +14,10 @@ class TestMechanizeHttpAuthRealm < Mechanize::TestCase
     assert_equal 'r', @realm.realm
 
     realm = @AR.new 'Digest', @uri, 'R'
-    assert_equal 'r', realm.realm
+    refute_equal 'r', realm.realm
+
+    realm = @AR.new 'Digest', @uri, 'R'
+    assert_equal 'R', realm.realm
 
     realm = @AR.new 'Digest', @uri, nil
     assert_nil realm.realm
@@ -28,6 +31,9 @@ class TestMechanizeHttpAuthRealm < Mechanize::TestCase
     refute_equal @realm, other
 
     other = @AR.new 'Digest', URI('http://other.example/'), 'r'
+    refute_equal @realm, other
+
+    other = @AR.new 'Digest', @uri, 'R'
     refute_equal @realm, other
 
     other = @AR.new 'Digest', @uri, 's'

--- a/test/test_mechanize_http_auth_store.rb
+++ b/test/test_mechanize_http_auth_store.rb
@@ -57,6 +57,20 @@ class TestMechanizeHttpAuthStore < Mechanize::TestCase
     assert_equal expected, @store.auth_accounts
   end
 
+  def test_add_auth_realm_case
+    @store.add_auth @uri, 'user1', 'pass', 'realm'
+    @store.add_auth @uri, 'user2', 'pass', 'Realm'
+
+    expected = {
+      @uri => {
+        'realm' => ['user1', 'pass', nil],
+        'Realm' => ['user2', 'pass', nil],
+      }
+    }
+
+    assert_equal expected, @store.auth_accounts
+  end
+
   def test_add_auth_string
     @store.add_auth "#{@uri}/path", 'user', 'pass'
 
@@ -143,6 +157,14 @@ class TestMechanizeHttpAuthStore < Mechanize::TestCase
     assert_equal ['user1', 'pass', nil], @store.credentials_for(@uri, 'other')
   end
 
+  def test_credentials_for_realm_case
+    @store.add_auth @uri, 'user1', 'pass', 'realm'
+    @store.add_auth @uri, 'user2', 'pass', 'Realm'
+
+    assert_equal ['user1', 'pass', nil], @store.credentials_for(@uri, 'realm')
+    assert_equal ['user2', 'pass', nil], @store.credentials_for(@uri, 'Realm')
+  end
+
   def test_credentials_for_path
     @store.add_auth @uri, 'user', 'pass', 'realm'
 
@@ -177,6 +199,21 @@ class TestMechanizeHttpAuthStore < Mechanize::TestCase
     expected = {
       @uri => {
         nil => ['user1', 'pass', nil]
+      }
+    }
+
+    assert_equal expected, @store.auth_accounts
+  end
+
+  def test_remove_auth_realm_case
+    @store.add_auth @uri, 'user1', 'pass', 'realm'
+    @store.add_auth @uri, 'user2', 'pass', 'Realm'
+
+    @store.remove_auth @uri, 'Realm'
+
+    expected = {
+      @uri => {
+        'realm' => ['user1', 'pass', nil]
       }
     }
 

--- a/test/test_mechanize_http_www_authenticate_parser.rb
+++ b/test/test_mechanize_http_www_authenticate_parser.rb
@@ -109,6 +109,14 @@ class TestMechanizeHttpWwwAuthenticateParser < Mechanize::TestCase
     assert_equal expected, @parser.parse('Basic ReAlM=foo')
   end
 
+  def test_parse_realm_value_case
+    expected = [
+      challenge('Basic', { 'realm' => 'Foo' }, 'Basic realm=Foo'),
+    ]
+
+    assert_equal expected, @parser.parse('Basic realm=Foo')
+  end
+
   def test_parse_scheme_uppercase
     expected = [
       challenge('Basic', { 'realm' => 'foo' }, 'BaSiC realm=foo'),


### PR DESCRIPTION
This PR fixes issue #458: Basic authentication fails when specifying credentials for a realm that contains uppercase characters.

This PR adds various tests for case sensitivity in realm name and fixes the issue itself.

All tests pass with this fix.