### PR TITLE
Update JRuby versions for testing in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ notifications:
   - ljjarvis@gmail.com
   - knu@idaemons.org
 sudo: false
+# bundler is missing for jruby-head in travis-ci
+# https://github.com/travis-ci/travis-ci/issues/5861
+before_install: gem query -i -n ^bundler$ >/dev/null || gem install bundler
 rvm:
 - 1.9.3
 - 2.0.0
@@ -13,7 +16,8 @@ rvm:
 - 2.2
 - 2.3.1
 - ruby-head
-- jruby-19mode
+- jruby-1.7.25
+- jruby-9.1.2.0
 - jruby-head
 - rbx-19mode
 script: rake test
@@ -21,6 +25,7 @@ matrix:
   allow_failures:
     - rvm: 2.3
     - rvm: ruby-head
-    - rvm: jruby-19mode
+    - rvm: jruby-1.7.25
+    - rvm: jruby-9.1.2.0
     - rvm: jruby-head
     - rvm: rbx-19mode


### PR DESCRIPTION
The RVM alias jruby-19mode is outdated (JRuby 1.7.19)
JRuby 9.1 is the active branch
JRuby 1.7 is maintained with no EOL announced