### PR TITLE
EXAMPLES.rdoc: Fix form id in Google example

### DIFF
--- a/EXAMPLES.rdoc
+++ b/EXAMPLES.rdoc
@@ -15,7 +15,7 @@ example, <code>do ... end.submit</code> is the same as <code>{ ...
   }
 
   a.get('http://google.com/') do |page|
-    search_result = page.form_with(:id => 'gbqf') do |search|
+    search_result = page.form_with(:id => 'tsf') do |search|
       search.q = 'Hello world'
     end.submit
 


### PR DESCRIPTION
The Google example in the current version of EXAMPLES.rdoc will crash
because Google has changed the form id used to submit a search on
their homepage. This pull request will fix the form id in the Google
example so that it does not crash.
