### PR TITLE
Make element(s)_with(search: selector) work as advertised

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,10 @@
 = Mechanize CHANGELOG
 
+=== Unreleased
+
+* Bug fix
+  * Fix element(s)_with(search: selector) methods not working for forms, form fields and frames. (#444)
+
 === 2.7.5
 
 * New Features

--- a/lib/mechanize/element_matcher.rb
+++ b/lib/mechanize/element_matcher.rb
@@ -15,6 +15,9 @@ module Mechanize::ElementMatcher
               h[:dom_class] = v
             when :search, :xpath, :css
               if v
+                if method
+                  warn "multiple search selectors are given; previous selector (\#{method}: \#{selector.inspect}) is ignored."
+                end
                 selector = v
                 method = k
               end

--- a/lib/mechanize/element_matcher.rb
+++ b/lib/mechanize/element_matcher.rb
@@ -29,7 +29,7 @@ module Mechanize::ElementMatcher
 
         f = select_#{plural}(selector, method).find_all do |thing|
           criteria.all? do |k,v|
-            v === thing.send(k)
+            v === thing.__send__(k)
           end
         end
         yield f if block_given?

--- a/lib/mechanize/form/field.rb
+++ b/lib/mechanize/form/field.rb
@@ -14,6 +14,8 @@
 #   field.value = "foo"
 
 class Mechanize::Form::Field
+  extend Forwardable
+
   attr_accessor :name, :value, :node, :type
 
   # This fields value before it's sent through Util.html_unescape.
@@ -66,6 +68,50 @@ class Mechanize::Form::Field
   def dom_class
     node['class']
   end
+
+  ##
+  # :method: search
+  #
+  # Shorthand for +node.search+.
+  #
+  # See Nokogiri::XML::Node#search for details.
+
+  ##
+  # :method: css
+  #
+  # Shorthand for +node.css+.
+  #
+  # See also Nokogiri::XML::Node#css for details.
+
+  ##
+  # :method: xpath
+  #
+  # Shorthand for +node.xpath+.
+  #
+  # See also Nokogiri::XML::Node#xpath for details.
+
+  ##
+  # :method: at
+  #
+  # Shorthand for +node.at+.
+  #
+  # See also Nokogiri::XML::Node#at for details.
+
+  ##
+  # :method: at_css
+  #
+  # Shorthand for +node.at_css+.
+  #
+  # See also Nokogiri::XML::Node#at_css for details.
+
+  ##
+  # :method: at_xpath
+  #
+  # Shorthand for +node.at_xpath+.
+  #
+  # See also Nokogiri::XML::Node#at_xpath for details.
+
+  def_delegators :node, :search, :css, :xpath, :at, :at_css, :at_xpath
 
   def inspect # :nodoc:
     "[%s:0x%x type: %s name: %s value: %s]" % [

--- a/lib/mechanize/form/multi_select_list.rb
+++ b/lib/mechanize/form/multi_select_list.rb
@@ -12,19 +12,15 @@
 #   list.value = 'one'
 
 class Mechanize::Form::MultiSelectList < Mechanize::Form::Field
-
   extend Mechanize::ElementMatcher
 
   attr_accessor :options
 
   def initialize node
     value = []
-    @options = []
-
-    # parse
-    node.search('option').each do |n|
-      @options << Mechanize::Form::Option.new(n, self)
-    end
+    @options = node.search('option').map { |n|
+      Mechanize::Form::Option.new(n, self)
+    }
 
     super node, value
   end

--- a/lib/mechanize/form/option.rb
+++ b/lib/mechanize/form/option.rb
@@ -8,12 +8,13 @@
 #   select_list.first.tick
 
 class Mechanize::Form::Option
-  attr_reader :value, :selected, :text, :select_list
+  attr_reader :value, :selected, :text, :select_list, :node
 
   alias :to_s :value
   alias :selected? :selected
 
   def initialize(node, select_list)
+    @node     = node
     @text     = node.inner_text
     @value    = Mechanize::Util.html_unescape(node['value'] || node.inner_text)
     @selected = node.has_attribute? 'selected'

--- a/lib/mechanize/page/frame.rb
+++ b/lib/mechanize/page/frame.rb
@@ -11,6 +11,8 @@ class Mechanize::Page::Frame < Mechanize::Page::Link
   attr_reader :text
   alias :name :text
 
+  attr_reader :node
+
   def initialize(node, mech, referer)
     super(node, mech, referer)
     @node = node

--- a/test/htdocs/find_link.html
+++ b/test/htdocs/find_link.html
@@ -11,13 +11,10 @@
         <A HREF="http://blargle.com/">blargle</A>
         <A HREF="http://a.cpan.org/">CPAN A</A>
         <A HREF="http://b.cpan.org/">CPAN B</A>
-        <FRAME SRC="foo.html">
-        <FRAME SRC="bar.html">
         <A HREF="http://c.cpan.org/" NAME="bongo">CPAN C</A>
         <A HREF="http://d.cpan.org/">CPAN D</A>
 
         <A HREF="http://www.msnbc.com/">MSNBC</A>
-        <FRAME SRC="http://www.oreilly.com/" NAME="wongo">
         <A HREF="http://www.cnn.com/">CNN</A>
         <A HREF="http://www.bbc.co.uk/" NAME="Wilma">BBC</A>
         <A HREF="http://www.msnbc.com/">News</A>

--- a/test/htdocs/find_link.html
+++ b/test/htdocs/find_link.html
@@ -35,7 +35,7 @@
         <!-- new stuff -->
         <A HREF="http://nowhere.org/" Name="Here">NoWhere</A>
         <A HREF="http://nowhere.org/padded" Name=" Here "> NoWhere </A>
-        <A HREF="blongo.html">Blongo!</A>
+        <A HREF="form_test.html" class="formtest">Form Test</A>
     </body>
 </html>
 

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -863,15 +863,19 @@ class TestMechanizeForm < Mechanize::TestCase
   def test_form_and_fields_dom_id
     # blatant copypasta of test above
     page = @mech.get("http://localhost/form_test.html")
-    form = page.form_with(:dom_id => 'generic_form')
-    form_by_id = page.form_with(:id => 'generic_form')
+    form = page.form_with(dom_id: 'generic_form')
 
-    assert_equal(1, form.fields_with(:dom_id => 'name_first').length)
-    assert_equal('first_name', form.field_with(:dom_id => 'name_first').name)
+    assert_equal(1, form.fields_with(dom_id: 'name_first').length)
+    assert_equal('first_name', form.field_with(dom_id: 'name_first').name)
 
-    #  *_with(:id => blah) should work exactly like (:dom_id => blah)
-    assert_equal(form, form_by_id)
-    assert_equal(form.fields_with(:dom_id => 'name_first'), form.fields_with(:id => 'name_first'))
+    assert_equal(form, page.form_with(id: 'generic_form'))
+    assert_equal(form, page.form_with(css: '#generic_form'))
+
+    fields_by_dom_id = form.fields_with(dom_id: 'name_first')
+    assert_equal(fields_by_dom_id, form.fields_with(id: 'name_first'))
+    assert_equal(fields_by_dom_id, form.fields_with(css: '#name_first'))
+    assert_equal(fields_by_dom_id, form.fields_with(xpath: '//*[@id="name_first"]'))
+    assert_equal(fields_by_dom_id, form.fields_with(search: '//*[@id="name_first"]'))
   end
 
   def test_form_and_fields_dom_class

--- a/test/test_mechanize_form_check_box.rb
+++ b/test/test_mechanize_form_check_box.rb
@@ -8,6 +8,16 @@ class TestMechanizeFormCheckBox < Mechanize::TestCase
     @page = @mech.get('http://localhost/tc_checkboxes.html')
   end
 
+  def test_search
+    form = @page.forms.first
+
+    checkbox = form.checkbox_with(name: 'green')
+    assert_equal('green', checkbox.name)
+
+    assert_equal(checkbox, form.checkbox_with('green'))
+    assert_equal(checkbox, form.checkbox_with(search: 'input[@type=checkbox][@name=green]'))
+  end
+
   def test_check
     form = @page.forms.first
 

--- a/test/test_mechanize_form_multi_select_list.rb
+++ b/test/test_mechanize_form_multi_select_list.rb
@@ -32,9 +32,13 @@ class TestMechanizeFormMultiSelectList < Mechanize::TestCase
   end
 
   def test_option_with
-    option = @select.option_with :value => '1'
+    option = @select.option_with value: '1'
 
     assert_equal '1', option.value
+
+    option = @select.option_with search: 'option[@selected]'
+
+    assert_equal '2', option.value
   end
 
   def test_options_with

--- a/test/test_mechanize_link.rb
+++ b/test/test_mechanize_link.rb
@@ -2,6 +2,25 @@ require 'mechanize/test_case'
 
 class TestMechanizeLink < Mechanize::TestCase
 
+  def test_search
+    page = @mech.get("http://localhost/find_link.html")
+    link = page.link_with(text: "Form Test")
+
+    assert_equal('Form Test', link.text)
+
+    link_with_search = page.link_with(search: "//*[text()='Form Test']")
+    assert_equal(link, link_with_search)
+
+    link_with_xpath = page.link_with(xpath: "//*[text()='Form Test']")
+    assert_equal(link, link_with_xpath)
+
+    link_with_css = page.link_with(css: ".formtest")
+    assert_equal(link, link_with_css)
+
+    link_with_class = page.link_with(class: "formtest")
+    assert_equal(link, link_with_class)
+  end
+
   def test_click
     page = @mech.get("http://localhost/frame_test.html")
     link = page.link_with(:text => "Form Test")

--- a/test/test_mechanize_page.rb
+++ b/test/test_mechanize_page.rb
@@ -108,6 +108,8 @@ class TestMechanizePage < Mechanize::TestCase
     assert_equal "frame3",            page.frames[2].name
     assert_equal "/file_upload.html", page.frames[2].src
     assert_equal "File Upload Form",  page.frames[2].content.title
+
+    assert_equal %w[/google.html /file_upload.html], page.frames_with(search: '*[name=frame1], *[name=frame3]').map(&:src)
   end
 
   def test_iframes


### PR DESCRIPTION
They would work for such elements as links and images, but never for forms, form fields and frames.

This fixes #444.