### PR TITLE
Travis: Rubies updated, add 2.4.0, fix 2.0.0, 1.9.3; update to jruby-9.1.7.0, add JRUBY_OPTS=--debug 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,31 @@ notifications:
   - drbrain@segment7.net
   - ljjarvis@gmail.com
   - knu@idaemons.org
+
 sudo: false
+
 # bundler is missing for jruby-head in travis-ci
 # https://github.com/travis-ci/travis-ci/issues/5861
-before_install: gem install --conservative bundler
-rvm:
-- 1.9.3
-- 2.0.0
-- 2.1
-- 2.2
-- 2.3.1
-- ruby-head
-- jruby-1.7.26
-- jruby-9.1.5.0
-- jruby-head
+before_install:
+  - gem install --conservative bundler -v'1.13.7'
+
 script: rake test
+
 matrix:
-  allow_failures:
+  include:
     - rvm: 1.9.3
     - rvm: 2.0.0
+    - rvm: 2.1
+    - rvm: 2.2
+    - rvm: 2.3.3
+    - rvm: 2.4.0
     - rvm: ruby-head
-    - rvm: jruby-9.1.5.0
+    - rvm: jruby-1.7.26
+      env: JRUBY_OPTS=--debug
+    - rvm: jruby-9.1.7.0
+      env: JRUBY_OPTS=--debug
+    - rvm: jruby-head
+      env: JRUBY_OPTS=--debug    
+  allow_failures:
+    - rvm: jruby-9.1.7.0
     - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
+# In order to be able to install on 1.9.3 and 2.0.0
+ruby RUBY_VERSION
+
 gemspec

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-= Mechanize {<img src="https://secure.travis-ci.org/sparklemotion/mechanize.svg?rvm=2.3.1" />}[http://travis-ci.org/sparklemotion/mechanize]
+= Mechanize {<img src="https://secure.travis-ci.org/sparklemotion/mechanize.svg?rvm=2.3.3" />}[http://travis-ci.org/sparklemotion/mechanize]
 
 * http://docs.seattlerb.org/mechanize
 * https://github.com/sparklemotion/mechanize


### PR DESCRIPTION
This PR organizes the Travis build matrix so that it's possible to add specific ENV vars to specific Rubies (without making the ENV settings global, nor turning them into a build combination for each Ruby).

- JRuby builds: add `env` with `JRUBY_OPTS=--debug`
- add 2.4.0 to matrix - it builds green
- update JRuby 9.1.5.0 to latest stable - 9.1.7.0
- use a Bundler v1.13.7
- 1.9.3 and 2.0.0 now build green - using the `ruby RUBY_VERSION` marker in the Gemfile
