### PR TITLE
Travis: update JRuby to latest jruby-9.1.14.0, jruby-1.7.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,13 @@ matrix:
     - rvm: 2.3.3
     - rvm: 2.4.0
     - rvm: ruby-head
-    - rvm: jruby-1.7.26
-      env: JRUBY_OPTS=--debug
-    - rvm: jruby-9.1.7.0
-      env: JRUBY_OPTS=--debug
+    - rvm: jruby-1.7.27
+    - rvm: jruby-9.1.14.0
     - rvm: jruby-head
-      env: JRUBY_OPTS=--debug    
   allow_failures:
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.14.0
     - rvm: jruby-head
+
+env:
+  global:
+    - JRUBY_OPTS="--debug"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/11/08/jruby-9-1-14-0.html

Also: JRuby 1.7.27 is updated.