### PR TITLE
support parsing of content disposition header with empty filename

### DIFF
--- a/lib/mechanize/parser.rb
+++ b/lib/mechanize/parser.rb
@@ -118,13 +118,13 @@ module Mechanize::Parser
     end
 
     # Set the filename
-    if disposition = @response['content-disposition'] then
+    if (disposition = @response['content-disposition'])
       content_disposition =
         Mechanize::HTTP::ContentDispositionParser.parse disposition
 
-      if content_disposition && content_disposition.filename && content_disposition.filename != '' then
+      if content_disposition && content_disposition.filename && content_disposition.filename != ''
         filename = content_disposition.filename
-        filename = filename.split(/[\\\/]/).last
+        filename = filename.rpartition(/[\\\/]/).last
         handled = true
       end
     end

--- a/test/test_mechanize_parser.rb
+++ b/test/test_mechanize_parser.rb
@@ -162,6 +162,16 @@ class TestMechanizeParser < Mechanize::TestCase
     end
   end
 
+  def test_extract_filename_content_disposition_empty
+    @parser.uri = URI 'http://example'
+
+    @parser.response = {
+      'content-disposition' => 'inline; filename="/"'
+    }
+
+    assert_equal '', @parser.extract_filename
+  end
+
   def test_extract_filename_host
     @parser.response = {}
     @parser.uri = URI 'http://example'


### PR DESCRIPTION
Currently http responses such as `Content-Disposition: 'inline; filename="/"` will cause an exception  because `'/'.split(/[\\\/]/).last` will result in `nil`, which we later try to truncate and get `NoMethodError (undefined method 'tr' for nil:NilClass)` raised.
Using `rpartition` allows to support that edge case while not breaking anything else(in this case' filename will be an empty string, instead of `nil`)