### PR TITLE
Add parametr no_default_headers for fetch method

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -438,7 +438,7 @@ class Mechanize
   # +parameters+ is formatted into a query string using
   # Mechanize::Util.build_query_string, which see.
 
-  def get(uri, parameters = [], referer = nil, headers = {})
+  def get(uri, parameters = [], referer = nil, headers = {}, no_default_headers = false)
     method = :get
 
     referer ||=
@@ -461,7 +461,7 @@ class Mechanize
 
     # fetch the page
     headers ||= {}
-    page = @agent.fetch uri, method, headers, parameters, referer
+    page = @agent.fetch uri, method, headers, parameters, referer, no_default_headers
     add_to_history(page)
     yield page if block_given?
     page
@@ -507,7 +507,7 @@ class Mechanize
   #   agent.post('http://example.com/', "<message>hello</message>",
   #              'Content-Type' => 'application/xml')
 
-  def post(uri, query = {}, headers = {})
+  def post(uri, query = {}, headers = {}, no_default_headers = false)
     return request_with_entity(:post, uri, query, headers) if String === query
 
     node = {}
@@ -1306,7 +1306,7 @@ Use of #auth and #basic_auth are deprecated due to a security vulnerability.
   ##
   # Posts +form+ to +uri+
 
-  def post_form(uri, form, headers = {})
+  def post_form(uri, form, headers = {}, no_default_headers = false)
     cur_page = form.page || current_page ||
       Page.new
 
@@ -1320,7 +1320,7 @@ Use of #auth and #basic_auth are deprecated due to a security vulnerability.
     }.merge headers
 
     # fetch the page
-    page = @agent.fetch uri, :post, headers, [request_data], cur_page
+    page = @agent.fetch uri, :post, headers, [request_data], cur_page, no_default_headers
     add_to_history(page)
     page
   end

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -228,7 +228,7 @@ class Mechanize::HTTP::Agent
   # page.  If it is over the redirection_limit an error will be raised.
 
   def fetch uri, method = :get, headers = {}, params = [],
-            referer = current_page, redirects = 0
+            referer = current_page, redirects = 0, no_default_headers = false
 
     referer_uri = referer ? referer.uri : nil
     uri         = resolve uri, referer
@@ -237,13 +237,15 @@ class Mechanize::HTTP::Agent
     connection  = connection_for uri
 
     request_auth             request, uri
-    disable_keep_alive       request
-    enable_gzip              request
-    request_language_charset request
-    request_cookies          request, uri
-    request_host             request, uri
-    request_referer          request, uri, referer_uri
-    request_user_agent       request
+    unless no_default_headers
+      disable_keep_alive       request
+      enable_gzip              request
+      request_language_charset request
+      request_cookies          request, uri
+      request_host             request, uri
+      request_referer          request, uri, referer_uri
+      request_user_agent       request
+    end
     request_add_headers      request, headers
     pre_connect              request
 


### PR DESCRIPTION
Add this parameter for methods get, post, fetch.
This parameter is set to false by default.
If parameter is true, default headers like: accept, user-agent etc, are not set.

This flag is needed if you want to make a request to a page without any headers.