### PR TITLE
#493 multiple titles

### DIFF
--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -58,7 +58,7 @@ class Mechanize::Page < Mechanize::File
   def title
     @title ||=
       if doc = parser
-        title = doc.search('title').inner_text
+        title = doc.search('html > head > title').inner_text
         title.empty? ? nil : title
       end
   end

--- a/test/test_mechanize_page.rb
+++ b/test/test_mechanize_page.rb
@@ -250,5 +250,31 @@ class TestMechanizePage < Mechanize::TestCase
     assert_empty page.links_with(:search => '//img')
   end
 
+	def test_multiple_titles
+		page = html_page <<-BODY
+<!doctype html>
+<html>
+	<head>
+		<title>HTMLTITLE</title>
+	</head>
+	<body>
+		<svg>
+			<title>SVGTITLE</title>
+			<metadata id="metadata5">
+				<rdf:RDF>
+					<cc:Work>
+						<dc:title>RDFDCTITLE</dc:title>
+					</cc:Work>
+				</rdf:RDF>
+			</metadata>
+			<g></g>
+		</svg>
+	</body>
+</html>
+		BODY
+
+		assert_equal page.title, "HTMLTITLE"
+	end
+
 end
 


### PR DESCRIPTION
As in #493 described, Mechanize currently returns the concatinated text of all found `<title>` tags, even if they belong to SVG or RDF subcontent. This PR changes this behaviour, so only the expected HTML-title is returned.