### PR TITLE
Clean up tests for minitest 5 deprecations.

### DIFF
--- a/lib/mechanize/test_case/http_refresh_servlet.rb
+++ b/lib/mechanize/test_case/http_refresh_servlet.rb
@@ -3,7 +3,7 @@ class HttpRefreshServlet < WEBrick::HTTPServlet::AbstractServlet
     res['Content-Type'] = req.query['ct'] || "text/html"
     refresh_time = req.query['refresh_time'] || 0
     refresh_url = req.query['refresh_url'] || '/'
-    res['Refresh'] = " #{refresh_time};url=#{refresh_url}\r\n";
+    res['Refresh'] = " #{refresh_time};url=#{refresh_url}";
   end
 end
 

--- a/lib/mechanize/test_case/infinite_refresh_servlet.rb
+++ b/lib/mechanize/test_case/infinite_refresh_servlet.rb
@@ -4,7 +4,7 @@ class InfiniteRefreshServlet < WEBrick::HTTPServlet::AbstractServlet
     res['Content-Type'] = req.query['ct'] || "text/html"
     res.status = req.query['code'] ? req.query['code'].to_i : '302'
     number = req.query['q'] ? req.query['q'].to_i : 0
-    res['Refresh'] = "0;url=http://#{address}/infinite_refresh?q=#{number + 1}\r\n";
+    res['Refresh'] = "0;url=http://#{address}/infinite_refresh?q=#{number + 1}";
   end
 end
 

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -943,7 +943,7 @@ but not <a href="/" rel="me nofollow">this</a>!
       "Content-Disposition: form-data; name=\"userfile1\"; filename=\"#{name}\"",
       page.body
     )
-    assert_send [page.body.bytesize, :>, File.size(__FILE__)]
+    assert_operator page.body.bytesize, :>, File.size(__FILE__)
   end
 
   def test_post_file_upload_nonascii
@@ -962,7 +962,7 @@ but not <a href="/" rel="me nofollow">this</a>!
       page.body
     )
     assert_match("Content-Type: application/zip", page.body)
-    assert_send [page.body.bytesize, :>, File.size(__FILE__)]
+    assert_operator page.body.bytesize, :>, File.size(__FILE__)
   end
 
   def test_post_file_upload
@@ -981,7 +981,7 @@ but not <a href="/" rel="me nofollow">this</a>!
       page.body
     )
     assert_match("Content-Type: application/zip", page.body)
-    assert_send [page.body.bytesize, :>, File.size(__FILE__)]
+    assert_operator page.body.bytesize, :>, File.size(__FILE__)
   end
 
   def test_post_redirect

--- a/test/test_mechanize_cookie.rb
+++ b/test/test_mechanize_cookie.rb
@@ -458,7 +458,7 @@ class TestMechanizeCookie < Mechanize::TestCase
     cookie = Mechanize::Cookie.new('key', 'value')
     assert_equal 'key', cookie.name
     assert_equal 'value', cookie.value
-    assert_equal nil, cookie.expires
+    assert_nil cookie.expires
 
     # Minimum unit for the expires attribute is second
     expires = Time.at((Time.now + 3600).to_i)

--- a/test/test_mechanize_cookie_jar.rb
+++ b/test/test_mechanize_cookie_jar.rb
@@ -294,8 +294,7 @@ class TestMechanizeCookieJar < Mechanize::TestCase
     # Add one cookie with an expiration date in the future
     cookie = Mechanize::Cookie.new(cookie_values)
     s_cookie = Mechanize::Cookie.new(cookie_values(:name => 'Bar',
-                                              :expires => nil,
-                                              :session => true))
+                                              :expires => nil))
 
     @jar.add(url, cookie)
     @jar.add(url, s_cookie)
@@ -321,8 +320,7 @@ class TestMechanizeCookieJar < Mechanize::TestCase
     # Add one cookie with an expiration date in the future
     cookie = Mechanize::Cookie.new(cookie_values)
     s_cookie = Mechanize::Cookie.new(cookie_values(:name => 'Bar',
-                                              :expires => nil,
-                                              :session => true))
+                                              :expires => nil))
 
     @jar.add(url, cookie)
     @jar.add(url, s_cookie)
@@ -348,8 +346,7 @@ class TestMechanizeCookieJar < Mechanize::TestCase
     # Add one cookie with an expiration date in the future
     cookie = Mechanize::Cookie.new(cookie_values)
     s_cookie = Mechanize::Cookie.new(cookie_values(:name => 'Bar',
-                                              :expires => nil,
-                                              :session => true))
+                                              :expires => nil))
 
     @jar.add(url, cookie)
     @jar.add(url, s_cookie)

--- a/test/test_mechanize_cookie_jar.rb
+++ b/test/test_mechanize_cookie_jar.rb
@@ -6,6 +6,30 @@ class TestMechanizeCookieJar < Mechanize::TestCase
     super
 
     @jar = Mechanize::CookieJar.new
+
+    @jar.extend Minitest::Assertions
+
+    def @jar.add(*args)
+      capture_io { super }
+    end
+
+    def @jar.jar(*args)
+      result = nil
+      capture_io { result = super }
+      result
+    end
+
+    def @jar.save_as(*args)
+      result = nil
+      capture_io { result = super }
+      result
+    end
+
+    def @jar.clear!(*args)
+      result = nil
+      capture_io { result = super }
+      result
+    end
   end
 
   def cookie_values(options = {})

--- a/test/test_mechanize_file_response.rb
+++ b/test/test_mechanize_file_response.rb
@@ -5,7 +5,7 @@ class TestMechanizeFileResponse < Mechanize::TestCase
   def test_content_type
     Tempfile.open %w[pi .nothtml] do |tempfile|
       res = Mechanize::FileResponse.new tempfile.path
-      assert_equal nil, res['content-type']
+      assert_nil res['content-type']
     end
 
     Tempfile.open %w[pi .xhtml] do |tempfile|

--- a/test/test_mechanize_form_encoding.rb
+++ b/test/test_mechanize_form_encoding.rb
@@ -67,7 +67,7 @@ class TestMechanizeFormEncoding < Mechanize::TestCase
     node['enctype'] = 'application/x-www-form-urlencoded'
     form = Mechanize::Form.new(node)
 
-    assert_equal nil, form.encoding
+    assert_nil form.encoding
   end
 
   def test_post_form_with_form_encoding

--- a/test/test_mechanize_page_image.rb
+++ b/test/test_mechanize_page_image.rb
@@ -147,7 +147,7 @@ class TestMechanizePageImage < Mechanize::TestCase
 
     assert_equal 'https', page.uri.scheme
     assert_equal false, page.images.first.relative?
-    assert_equal nil, requests.first['Referer']
+    assert_nil requests.first['Referer']
   end
 
   def test_image_referer_http_page_abs_src

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -72,7 +72,7 @@ class TestMechanizePageLink < Mechanize::TestCase
     assert_equal(URI("http://localhost/canonical_uri"), page.canonical_uri)
 
     page = @mech.get("http://localhost/file_upload.html")
-    assert_equal(nil, page.canonical_uri)
+    assert_nil page.canonical_uri
   end
 
   def test_canonical_uri_unescaped
@@ -339,7 +339,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   def test_title_none
     page = util_page '' # invalid HTML
 
-    assert_equal(nil, page.title)
+    assert_nil(page.title)
   end
 
   def test_page_decoded_with_charset

--- a/test/test_mechanize_page_meta_refresh.rb
+++ b/test/test_mechanize_page_meta_refresh.rb
@@ -112,7 +112,7 @@ class TestMechanizePageMetaRefresh < Mechanize::TestCase
     page = util_page 5, nil
     link = util_meta_refresh page
     assert_equal 5, link.delay
-    assert_equal nil, link.href
+    assert_nil link.href
 
     page = util_page 5, @uri
     link = util_meta_refresh page

--- a/test/test_mechanize_util.rb
+++ b/test/test_mechanize_util.rb
@@ -27,7 +27,7 @@ class TestMechanizeUtil < Mechanize::TestCase
 
   def test_from_native_charset_returns_nil_when_no_string
     @result = @MU.from_native_charset(nil, CONTENT_ENCODING)
-    assert_equal nil, @result
+    assert_nil @result
   end
 
   def test_from_native_charset_doesnot_convert_when_no_encoding


### PR DESCRIPTION
This cleans up all deprecation warnings from minitest. It still has failures (matching master) and warnings from mechanize deprecations (which I've disabled for this output):

```
10008 % rake
/Users/ryan/.rbenv/versions/2.4.2/bin/ruby -w -I"lib" -I"/Users/ryan/.gem/repos/mechanize/gems/rake-12.3.0/lib" "/Users/ryan/.gem/repos/mechanize/gems/rake-12.3.0/lib/rake/rake_test_loader.rb" "test/test_mechanize.rb" "test/test_mechanize_cookie.rb" "test/test_mechanize_cookie_jar.rb" "test/test_mechanize_directory_saver.rb" "test/test_mechanize_download.rb" "test/test_mechanize_element_not_found_error.rb" "test/test_mechanize_file.rb" "test/test_mechanize_file_connection.rb" "test/test_mechanize_file_request.rb" "test/test_mechanize_file_response.rb" "test/test_mechanize_file_saver.rb" "test/test_mechanize_form.rb" "test/test_mechanize_form_check_box.rb" "test/test_mechanize_form_encoding.rb" "test/test_mechanize_form_field.rb" "test/test_mechanize_form_file_upload.rb" "test/test_mechanize_form_image_button.rb" "test/test_mechanize_form_keygen.rb" "test/test_mechanize_form_multi_select_list.rb" "test/test_mechanize_form_option.rb" "test/test_mechanize_form_radio_button.rb" "test/test_mechanize_form_select_list.rb" "test/test_mechanize_form_textarea.rb" "test/test_mechanize_headers.rb" "test/test_mechanize_history.rb" "test/test_mechanize_http_agent.rb" "test/test_mechanize_http_auth_challenge.rb" "test/test_mechanize_http_auth_realm.rb" "test/test_mechanize_http_auth_store.rb" "test/test_mechanize_http_content_disposition_parser.rb" "test/test_mechanize_http_www_authenticate_parser.rb" "test/test_mechanize_image.rb" "test/test_mechanize_link.rb" "test/test_mechanize_page.rb" "test/test_mechanize_page_encoding.rb" "test/test_mechanize_page_frame.rb" "test/test_mechanize_page_image.rb" "test/test_mechanize_page_link.rb" "test/test_mechanize_page_meta_refresh.rb" "test/test_mechanize_parser.rb" "test/test_mechanize_pluggable_parser.rb" "test/test_mechanize_redirect_limit_reached_error.rb" "test/test_mechanize_redirect_not_get_or_head_error.rb" "test/test_mechanize_response_read_error.rb" "test/test_mechanize_subclass.rb" "test/test_mechanize_util.rb" "test/test_mechanize_xml_file.rb" "test/test_multi_select.rb" 
mechanize/cookie will be deprecated.  Please migrate to the http-cookie APIs.
mechanize/cookie_jar will be deprecated.  Please migrate to the http-cookie APIs.
Run options: --seed 19468

# Running:

.....................................................................................................................................................................................F...............E........E........E..................................................................................................................................................unknown attribute name: :session
..........unknown attribute name: :session
...................unknown attribute name: :session
...........................................................................................................................................................................................................................................................................................................................

Fabulous run in 0.958507s, 736.5622 runs/s, 2318.1886 assertions/s.

  1) Failure:
TestMechanize#test_get_redirect_infinite [/Users/ryan/Work/git/sparklemotion/mechanize/test/test_mechanize.rb:646]:
[Mechanize::RedirectLimitReachedError] exception expected, not
Class: <ArgumentError>
Message: <"header field value cannnot include CR/LF">
---Backtrace---
/Users/ryan/.rbenv/versions/2.4.2/lib/ruby/2.4.0/net/http/header.rb:80:in `set_field'
/Users/ryan/.rbenv/versions/2.4.2/lib/ruby/2.4.0/net/http/header.rb:45:in `[]='
/Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/test_case/infinite_refresh_servlet.rb:7:in `do_GET'
/Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/test_case.rb:229:in `request'
/Users/ryan/.gem/repos/mechanize/gems/net-http-persistent-2.9.4/lib/net/http/persistent.rb:999:in `request'
/Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/http/agent.rb:274:in `fetch'
/Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize.rb:464:in `get'
/Users/ryan/Work/git/sparklemotion/mechanize/test/test_mechanize.rb:647:in `block in test_get_redirect_infinite'
---------------

  2) Error:
TestMechanize#test_get_http_refresh:
ArgumentError: header field value cannnot include CR/LF
    /Users/ryan/.rbenv/versions/2.4.2/lib/ruby/2.4.0/net/http/header.rb:80:in `set_field'
    /Users/ryan/.rbenv/versions/2.4.2/lib/ruby/2.4.0/net/http/header.rb:45:in `[]='
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/test_case/http_refresh_servlet.rb:6:in `do_GET'
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/test_case.rb:229:in `request'
    /Users/ryan/.gem/repos/mechanize/gems/net-http-persistent-2.9.4/lib/net/http/persistent.rb:999:in `request'
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/http/agent.rb:274:in `fetch'
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize.rb:464:in `get'
    /Users/ryan/Work/git/sparklemotion/mechanize/test/test_mechanize.rb:593:in `test_get_http_refresh'

  3) Error:
TestMechanize#test_get_http_refresh_delay:
ArgumentError: header field value cannnot include CR/LF
    /Users/ryan/.rbenv/versions/2.4.2/lib/ruby/2.4.0/net/http/header.rb:80:in `set_field'
    /Users/ryan/.rbenv/versions/2.4.2/lib/ruby/2.4.0/net/http/header.rb:45:in `[]='
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/test_case/http_refresh_servlet.rb:6:in `do_GET'
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/test_case.rb:229:in `request'
    /Users/ryan/.gem/repos/mechanize/gems/net-http-persistent-2.9.4/lib/net/http/persistent.rb:999:in `request'
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/http/agent.rb:274:in `fetch'
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize.rb:464:in `get'
    /Users/ryan/Work/git/sparklemotion/mechanize/test/test_mechanize.rb:609:in `test_get_http_refresh_delay'

  4) Error:
TestMechanize#test_get_http_refresh_disabled:
ArgumentError: header field value cannnot include CR/LF
    /Users/ryan/.rbenv/versions/2.4.2/lib/ruby/2.4.0/net/http/header.rb:80:in `set_field'
    /Users/ryan/.rbenv/versions/2.4.2/lib/ruby/2.4.0/net/http/header.rb:45:in `[]='
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/test_case/http_refresh_servlet.rb:6:in `do_GET'
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/test_case.rb:229:in `request'
    /Users/ryan/.gem/repos/mechanize/gems/net-http-persistent-2.9.4/lib/net/http/persistent.rb:999:in `request'
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize/http/agent.rb:274:in `fetch'
    /Users/ryan/Work/git/sparklemotion/mechanize/lib/mechanize.rb:464:in `get'
    /Users/ryan/Work/git/sparklemotion/mechanize/test/test_mechanize.rb:614:in `test_get_http_refresh_disabled'

706 runs, 2222 assertions, 1 failures, 3 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -w -I"lib" -I"/Users/ryan/.gem/repos/mechanize/gems/rake-12.3.0/lib" "/Users/ryan/.gem/repos/mechanize/gems/rake-12.3.0/lib/rake/rake_test_loader.rb" "test/test_mechanize.rb" "test/test_mechanize_cookie.rb" "test/test_mechanize_cookie_jar.rb" "test/test_mechanize_directory_saver.rb" "test/test_mechanize_download.rb" "test/test_mechanize_element_not_found_error.rb" "test/test_mechanize_file.rb" "test/test_mechanize_file_connection.rb" "test/test_mechanize_file_request.rb" "test/test_mechanize_file_response.rb" "test/test_mechanize_file_saver.rb" "test/test_mechanize_form.rb" "test/test_mechanize_form_check_box.rb" "test/test_mechanize_form_encoding.rb" "test/test_mechanize_form_field.rb" "test/test_mechanize_form_file_upload.rb" "test/test_mechanize_form_image_button.rb" "test/test_mechanize_form_keygen.rb" "test/test_mechanize_form_multi_select_list.rb" "test/test_mechanize_form_option.rb" "test/test_mechanize_form_radio_button.rb" "test/test_mechanize_form_select_list.rb" "test/test_mechanize_form_textarea.rb" "test/test_mechanize_headers.rb" "test/test_mechanize_history.rb" "test/test_mechanize_http_agent.rb" "test/test_mechanize_http_auth_challenge.rb" "test/test_mechanize_http_auth_realm.rb" "test/test_mechanize_http_auth_store.rb" "test/test_mechanize_http_content_disposition_parser.rb" "test/test_mechanize_http_www_authenticate_parser.rb" "test/test_mechanize_image.rb" "test/test_mechanize_link.rb" "test/test_mechanize_page.rb" "test/test_mechanize_page_encoding.rb" "test/test_mechanize_page_frame.rb" "test/test_mechanize_page_image.rb" "test/test_mechanize_page_link.rb" "test/test_mechanize_page_meta_refresh.rb" "test/test_mechanize_parser.rb" "test/test_mechanize_pluggable_parser.rb" "test/test_mechanize_redirect_limit_reached_error.rb" "test/test_mechanize_redirect_not_get_or_head_error.rb" "test/test_mechanize_response_read_error.rb" "test/test_mechanize_subclass.rb" "test/test_mechanize_util.rb" "test/test_mechanize_xml_file.rb" "test/test_multi_select.rb" ]
/Users/ryan/.gem/repos/mechanize/gems/rake-12.3.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
10008 % 
```