### PR TITLE
Only prepend http:// if it wasn't provided

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -1211,9 +1211,9 @@ class Mechanize::HTTP::Agent
   end
 
   ##
-  # Sets the proxy address, port, user, and password +addr+ should be a host,
-  # with no "http://", +port+ may be a port number, service name or port
-  # number string.
+  # Sets the proxy address, port, user, and password. +addr+ should be a host,
+  # with or without "http://", +port+ may be a port number, service name or
+  # port number string.
 
   def set_proxy addr, port, user = nil, pass = nil
     unless addr and port then
@@ -1234,7 +1234,8 @@ class Mechanize::HTTP::Agent
       end
     end
 
-    proxy_uri = URI "http://#{addr}"
+    addr = "http://#{addr}" unless addr =~ %r(^https?://)
+    proxy_uri = URI addr
     proxy_uri.port = port
     proxy_uri.user     = user if user
     proxy_uri.password = pass if pass


### PR DESCRIPTION
This is a possible solution for issue https://github.com/sparklemotion/mechanize/issues/512 where Mechanize is forcing `http://` into the string, even if it was provided.

I don't know how far back in ruby versions things like `=~` and `%r(regex)` go, so if these need to be changed to get better backwards compat, I'm all ears!