### PR TITLE
Accept content-encoding identity

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -816,7 +816,7 @@ class Mechanize::HTTP::Agent
     return body_io if length.zero?
 
     out_io = case response['Content-Encoding']
-             when nil, 'none', '7bit', "" then
+             when nil, 'none', '7bit', 'identity', "" then
                body_io
              when 'deflate' then
                content_encoding_inflate body_io

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1065,6 +1065,14 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     assert_equal 'part', body.read
   end
 
+  def test_response_content_encoding_identity
+    @res.instance_variable_set :@header, 'content-encoding' => %w[identity]
+
+    body = @agent.response_content_encoding @res, StringIO.new('part')
+
+    assert_equal 'part', body.read
+  end
+
   def test_response_content_encoding_tempfile_7_bit
     body_io = tempfile 'part'
 


### PR DESCRIPTION
`identity` is a valid `content-encoding` header value https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding

Fixes https://github.com/sparklemotion/mechanize/issues/385