### PR TITLE
parse filename that starts with an escaped quote

### DIFF
--- a/lib/mechanize/http/content_disposition_parser.rb
+++ b/lib/mechanize/http/content_disposition_parser.rb
@@ -141,7 +141,10 @@ class Mechanize::HTTP::ContentDispositionParser
           text << " "
         end
       else
-        if '"' == @scanner.peek(1) then
+        if '\\"' == @scanner.peek(2) then
+          @scanner.skip(/\\/)
+          text << @scanner.get_byte
+        elsif '"' == @scanner.peek(1) then
           @scanner.get_byte
           break
         else

--- a/test/test_mechanize_http_content_disposition_parser.rb
+++ b/test/test_mechanize_http_content_disposition_parser.rb
@@ -119,13 +119,20 @@ class TestMechanizeHttpContentDispositionParser < Mechanize::TestCase
 
     assert_equal 'end "', string
   end
-  
+
   def test_parse_uppercase
     content_disposition = @parser.parse \
       'content-disposition: attachment; Filename=value', true
 
     assert_equal 'attachment', content_disposition.type
     assert_equal 'value',      content_disposition.filename
+  end
+
+  def test_parse_filename_starting_with_escaped_quote
+    content_disposition = @parser.parse \
+      'content-disposition: attachment; Filename="\"value\""', true
+
+    assert_equal '"value"', content_disposition.filename
   end
 
 end

--- a/test/test_mechanize_parser.rb
+++ b/test/test_mechanize_parser.rb
@@ -99,10 +99,10 @@ class TestMechanizeParser < Mechanize::TestCase
     @parser.uri = URI 'http://example'
 
     @parser.response = {
-      'content-disposition' => 'attachment; filename="some \"file\""'
+      'content-disposition' => 'attachment; filename="\"some \"file\""'
     }
 
-    assert_equal 'some__file_', @parser.extract_filename
+    assert_equal '_some__file_', @parser.extract_filename
   end
 
   def test_extract_filename_content_disposition_special


### PR DESCRIPTION
`ContentDispositionParser#parse` does not correctly parse the content disposition header when the filename has escaped quotes. In my case, the header was 
```
attachment; filename="\"G.I. Jive 1944\".mp3"; filename*=UTF-8''%22G.I.%20Jive%201944%22.mp3
```
According to [RFC 2616](https://tools.ietf.org/html/rfc6266#section-4.1), this is a valid header.

---------

I moved this fork into a new repository so I am closing #492 in favor of this. It would be great if this could be reviewed so that we do not have to rely on our fork.