### PR TITLE
Fix net http persistent tests

### DIFF
--- a/lib/mechanize/test_case/http_refresh_servlet.rb
+++ b/lib/mechanize/test_case/http_refresh_servlet.rb
@@ -3,7 +3,6 @@ class HttpRefreshServlet < WEBrick::HTTPServlet::AbstractServlet
     res['Content-Type'] = req.query['ct'] || "text/html"
     refresh_time = req.query['refresh_time'] || 0
     refresh_url = req.query['refresh_url'] || '/'
-    res['Refresh'] = " #{refresh_time};url=#{refresh_url}\r\n";
+    res['Refresh'] = " #{refresh_time};url=#{refresh_url}";
   end
 end
-

--- a/lib/mechanize/test_case/infinite_refresh_servlet.rb
+++ b/lib/mechanize/test_case/infinite_refresh_servlet.rb
@@ -4,7 +4,6 @@ class InfiniteRefreshServlet < WEBrick::HTTPServlet::AbstractServlet
     res['Content-Type'] = req.query['ct'] || "text/html"
     res.status = req.query['code'] ? req.query['code'].to_i : '302'
     number = req.query['q'] ? req.query['q'].to_i : 0
-    res['Refresh'] = "0;url=http://#{address}/infinite_refresh?q=#{number + 1}\r\n";
+    res['Refresh'] = "0;url=http://#{address}/infinite_refresh?q=#{number + 1}";
   end
 end
-

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -1087,25 +1087,21 @@ but not <a href="/" rel="me nofollow">this</a>!
 
     assert_match(/Hello World/, @mech.current_page.body)
     refute_empty @mech.cookies
-    refute_empty Thread.current[@mech.agent.http.request_key]
 
     @mech.shutdown
 
-    assert_nil Thread.current[@mech.agent.http.request_key]
     assert_empty @mech.history
     assert_empty @mech.cookies
   end
 
   def test_start
-    body, id = nil
+    body = nil
 
     Mechanize.start do |m|
       body = m.get("http://localhost/").body
-      id = m.agent.http.request_key
     end
 
     assert_match(/Hello World/, body)
-    assert_nil Thread.current[id]
   end
 
   def test_submit_bad_form_method
@@ -1363,4 +1359,3 @@ but not <a href="/" rel="me nofollow">this</a>!
     end
   end
 end
-


### PR DESCRIPTION
These test changes avoid testing the internals of `net-http-persistent` to unblock an update of the gem. See https://github.com/sparklemotion/mechanize/pull/499#issuecomment-365286603 for further background.