### PR TITLE
Travis: use jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ matrix:
     - rvm: 2.4.0
     - rvm: ruby-head
     - rvm: jruby-1.7.27
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.2.0.0
     - rvm: jruby-head
   allow_failures:
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.2.0.0
     - rvm: jruby-head
 
 env:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html