### PR TITLE
Remove unused kconv require

### DIFF
--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'tempfile'
 require 'net/ntlm'
-require 'kconv'
 require 'webrobots'
 
 ##
@@ -1279,4 +1278,3 @@ class Mechanize::HTTP::Agent
 end
 
 require 'mechanize/http/auth_store'
-


### PR DESCRIPTION
It seems to be `require 'kconv'` (Kanji converter in the standard Ruby libraries) is not used anywhere at all.

This found in truffle-ruby which hasn't been `kconv` yet in this issue https://github.com/oracle/truffleruby/issues/1439

This thing was introduced in this commit https://github.com/sparklemotion/mechanize/commit/5c8e802f35d53c355e4840c972ba0113f15b58e2