### PR TITLE
CI: JRuby 9.2.5.0; drop defunct Travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ notifications:
   - ljjarvis@gmail.com
   - knu@idaemons.org
 
-sudo: false
-
 # bundler is missing for jruby-head in travis-ci
 # https://github.com/travis-ci/travis-ci/issues/5861
 before_install:
@@ -25,10 +23,10 @@ matrix:
     - rvm: 2.4.0
     - rvm: ruby-head
     - rvm: jruby-1.7.27
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.5.0
     - rvm: jruby-head
   allow_failures:
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.5.0
     - rvm: jruby-head
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,10 @@ script: rake test
 
 matrix:
   include:
-    - rvm: 1.9.3
-    - rvm: 2.0.0
-    - rvm: 2.1
-    - rvm: 2.2
-    - rvm: 2.3.3
-    - rvm: 2.4.0
+    - rvm: 2.3.8
+    - rvm: 2.4.5
+    - rvm: 2.5.3
     - rvm: ruby-head
-    - rvm: jruby-1.7.27
     - rvm: jruby-9.2.5.0
     - rvm: jruby-head
   allow_failures:


### PR DESCRIPTION
This PR makes the CI matrix smaller and newer.

- updates the CI matrix to use latest JRuby, 9.2.5.0. [JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)
- Then, having read about the CI matrix changes in Nokogiri (which was failing this PR on JRuby 1.7), I changed this PR to also update all the other minor versions.

---

About the setting in Travis: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration