### PR TITLE
Clear credential headers when redirecting to cross site

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -9,7 +9,10 @@
 * New Features
   * Page::Link#uri now handles non-ASCII `href`s. (#569) @terryyin
   * FileConnection supports Windows drive letters (#483)
+  * Credential headers 'Authorization' and 'Cookie' are deleted on cross-origin redirects. (#538) @kyoshidajp
 
+* Bug fix
+  * POST headers 'Content-Length', 'Content-MD5', and 'Content-Type' are deleted in a case-insensitive manner on redirects. Previously these headers were treated as case-sensitive.
 
 === 2.7.7 / 2021-02-01
 

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -10,6 +10,8 @@ require 'webrobots'
 
 class Mechanize::HTTP::Agent
 
+  CREDENTIAL_HEADERS = ['Authorization', 'Cookie']
+
   # :section: Headers
 
   # Disables If-Modified-Since conditional requests (enabled by default)
@@ -995,6 +997,12 @@ class Mechanize::HTTP::Agent
     new_uri = secure_resolve! response['Location'].to_s, page
 
     @history.push(page, page.uri)
+
+    if new_uri.host != page.uri.host
+      CREDENTIAL_HEADERS.each do |ch|
+        headers.delete_if{ |h| h.downcase == ch.downcase }
+      end
+    end
 
     fetch new_uri, redirect_method, headers, [], referer, redirects + 1
   end

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -11,6 +11,7 @@ require 'webrobots'
 class Mechanize::HTTP::Agent
 
   CREDENTIAL_HEADERS = ['Authorization', 'Cookie']
+  POST_HEADERS = ['Content-Length', 'Content-MD5', 'Content-Type']
 
   # :section: Headers
 
@@ -993,8 +994,8 @@ class Mechanize::HTTP::Agent
     @history.push(page, page.uri)
 
     # Make sure we are not copying over the POST headers from the original request
-    ['Content-Length', 'Content-MD5', 'Content-Type'].each do |key|
-      headers.delete key
+    POST_HEADERS.each do |key|
+      headers.delete_if { |h| h.casecmp?(key) }
     end
 
     # Make sure we clear credential headers if being redirected to another site

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -989,18 +989,18 @@ class Mechanize::HTTP::Agent
 
     redirect_method = method == :head ? :head : :get
 
+    new_uri = secure_resolve!(response['Location'].to_s, page)
+    @history.push(page, page.uri)
+
     # Make sure we are not copying over the POST headers from the original request
     ['Content-Length', 'Content-MD5', 'Content-Type'].each do |key|
       headers.delete key
     end
 
-    new_uri = secure_resolve! response['Location'].to_s, page
-
-    @history.push(page, page.uri)
-
+    # Make sure we clear credential headers if being redirected to another site
     if new_uri.host != page.uri.host
       CREDENTIAL_HEADERS.each do |ch|
-        headers.delete_if{ |h| h.downcase == ch.downcase }
+        headers.delete_if { |h| h.casecmp?(ch) }
       end
     end
 

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1556,18 +1556,20 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     headers = {
       'Range' => 'bytes=0-9999',
-      'Content-Type' => 'application/x-www-form-urlencoded',
-      'Content-Length' => '9999',
-      'Authorization' => 'Basic xxx',
-      'Cookie' => 'name=value',
+      'AUTHORIZATION' => 'Basic xxx',
+      'cookie' => 'name=value',
     }
 
     page = html_page ''
-    @agent.response_redirect({ 'Location' => 'http://trap' }, :get,
-                             page, 0, headers)
+    page = @agent.response_redirect({ 'Location' => 'http://trap/http_headers' }, :get,
+                                    page, 0, headers)
 
-    assert !(headers.keys.include? 'Authorization')
-    assert !(headers.keys.include? 'Cookie')
+    refute_includes(headers.keys, "AUTHORIZATION")
+    refute_includes(headers.keys, "cookie")
+
+    assert_match 'range|bytes=0-9999', page.body
+    refute_match("authorization|Basic xxx", page.body)
+    refute_match("cookie|name=value", page.body)
   end
 
   def test_response_redirect_to_same_site_with_credential
@@ -1575,18 +1577,20 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     headers = {
       'Range' => 'bytes=0-9999',
-      'Content-Type' => 'application/x-www-form-urlencoded',
-      'Content-Length' => '9999',
-      'Authorization' => 'Basic xxx',
-      'Cookie' => 'name=value',
+      'AUTHORIZATION' => 'Basic xxx',
+      'cookie' => 'name=value',
     }
 
     page = html_page ''
-    @agent.response_redirect({ 'Location' => 'http://example' }, :get,
-                             page, 0, headers)
+    page = @agent.response_redirect({ 'Location' => '/http_headers' }, :get,
+                                    page, 0, headers)
 
-    assert headers.keys.include? 'Authorization'
-    assert headers.keys.include? 'Cookie'
+    assert_includes(headers.keys, "AUTHORIZATION")
+    assert_includes(headers.keys, "cookie")
+
+    assert_match 'range|bytes=0-9999', page.body
+    assert_match("authorization|Basic xxx", page.body)
+    assert_match("cookie|name=value", page.body)
   end
 
   def test_response_redirect_not_ok

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1551,6 +1551,44 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     end
   end
 
+  def test_response_redirect_to_cross_site_with_credential
+    @agent.redirect_ok = true
+
+    headers = {
+      'Range' => 'bytes=0-9999',
+      'Content-Type' => 'application/x-www-form-urlencoded',
+      'Content-Length' => '9999',
+      'Authorization' => 'Basic xxx',
+      'Cookie' => 'name=value',
+    }
+
+    page = html_page ''
+    @agent.response_redirect({ 'Location' => 'http://trap' }, :get,
+                             page, 0, headers)
+
+    assert !(headers.keys.include? 'Authorization')
+    assert !(headers.keys.include? 'Cookie')
+  end
+
+  def test_response_redirect_to_same_site_with_credential
+    @agent.redirect_ok = true
+
+    headers = {
+      'Range' => 'bytes=0-9999',
+      'Content-Type' => 'application/x-www-form-urlencoded',
+      'Content-Length' => '9999',
+      'Authorization' => 'Basic xxx',
+      'Cookie' => 'name=value',
+    }
+
+    page = html_page ''
+    @agent.response_redirect({ 'Location' => 'http://example' }, :get,
+                             page, 0, headers)
+
+    assert headers.keys.include? 'Authorization'
+    assert headers.keys.include? 'Cookie'
+  end
+
   def test_response_redirect_not_ok
     @agent.redirect_ok = false
 

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1504,7 +1504,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     headers = {
       'Range' => 'bytes=0-9999',
       'Content-Type' => 'application/x-www-form-urlencoded',
-      'Content-Length' => '9999',
+      'CONTENT-LENGTH' => '9999',
+      'content-md5' => '14758f1afd44c09b7992073ccf00b43d',
     }
 
     page = fake_page
@@ -1516,6 +1517,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     assert_match 'range|bytes=0-9999', page.body
     refute_match 'content-type|application/x-www-form-urlencoded', page.body
     refute_match 'content-length|9999', page.body
+    refute_match 'content-md5|14758f1afd44c09b7992073ccf00b43d', page.body
   end
 
   def test_response_redirect_malformed


### PR DESCRIPTION
Credential headers (Authorization and Cookie) are now forwarded to cross-site when redirection. Should be cleared these headers before redirection to protect leaking credential info.