### PR TITLE
CI: Using default script directive, allow Bundler to pick the gems needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,8 @@ notifications:
   - ljjarvis@gmail.com
   - knu@idaemons.org
 
-# bundler is missing for jruby-head in travis-ci
-# https://github.com/travis-ci/travis-ci/issues/5861
 before_install:
-  - gem install --conservative bundler -v'1.13.7'
-
-script: rake test
+  - gem install --conservative bundler -v'< 2'
 
 matrix:
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-# In order to be able to install on 1.9.3 and 2.0.0
-ruby RUBY_VERSION
+gem "rake"
+gem "bundler"
+gem "rdoc"
+gem "minitest"
 
 gemspec

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -58,9 +58,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ntlm-http",            [ ">= 0.1.1", "~> 0.1"   ]
   spec.add_runtime_dependency "webrobots",            [ "< 0.2",    ">= 0.0.9" ]
   spec.add_runtime_dependency "domain_name",          [ ">= 0.5.1", "~> 0.5"   ]
-
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "bundler",  "~> 1.3"
-  spec.add_development_dependency "rdoc",     "~> 4.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
This is an (experimental) PR to see if we can simplify away a few of the steps and comments in the Travis configuration.