### PR TITLE
Ignore fields without names in Form#build_query

### DIFF
--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -305,7 +305,7 @@ class Mechanize::Form
     successful_controls = []
 
     (fields + checkboxes).reject do |f|
-      f.node["disabled"]
+      f.node["disabled"] || f.node["name"] == ""
     end.sort.each do |f|
       case f
       when Mechanize::Form::CheckBox

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -65,6 +65,18 @@ class TestMechanizeForm < Mechanize::TestCase
     assert query.all? { |x| x[1] == '' }
   end
 
+  def test_build_query_blank_input_name
+    html = Nokogiri::HTML <<-HTML
+<form>
+  <input type="text" name="" value="foo" />
+</form>
+    HTML
+
+    form = Mechanize::Form.new html.at('form'), @mech, @page
+
+    assert_equal [], form.build_query
+  end
+
   def test_build_query_radio_button_duplicate
     html = Nokogiri::HTML <<-HTML
 <form>


### PR DESCRIPTION
We shouldn't try to submit empty strings to the server, since browsers
also simply ignore these fields

Fixes #536