### PR TITLE
CI: Update JRuby to 9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ matrix:
     - rvm: 2.4.5
     - rvm: 2.5.3
     - rvm: ruby-head
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
     - rvm: jruby-head
   allow_failures:
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
     - rvm: jruby-head
 
 env:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)

---

- This does not solve any of the three Zlib Gzip test failures, 
- This does not introduce any new failures.

<details>

```
  1) Error:
TestMechanize#test_get_gzip:
IOError: footer is not found
    org/jruby/ext/zlib/JZlibRubyGzipReader.java:576:in `eof'
    org/jruby/ext/zlib/JZlibRubyGzipReader.java:582:in `eof?'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:1183:in `auto_io'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:447:in `content_encoding_gunzip'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:830:in `response_content_encoding'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:296:in `fetch'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize.rb:464:in `get'
    /home/travis/build/sparklemotion/mechanize/test/test_mechanize.rb:551:in `test_get_gzip'
  2) Error:
TestMechanize#test_content_encoding_hooks_body_io:
Zlib::GzipFile::NoFooter: footer is not found
    org/jruby/ext/zlib/JZlibRubyGzipReader.java:349:in `read'
    /home/travis/build/sparklemotion/mechanize/test/test_mechanize.rb:574:in `external_cmd'
    /home/travis/build/sparklemotion/mechanize/test/test_mechanize.rb:582:in `block in test_content_encoding_hooks_body_io'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:392:in `block in hook_content_encoding'
    org/jruby/RubyArray.java:1792:in `each'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:391:in `hook_content_encoding'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:294:in `fetch'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize.rb:464:in `get'
    /home/travis/build/sparklemotion/mechanize/test/test_mechanize.rb:585:in `test_content_encoding_hooks_body_io'
  3) Error:
TestMechanize#test_content_encoding_hooks_header:
IOError: footer is not found
    org/jruby/ext/zlib/JZlibRubyGzipReader.java:576:in `eof'
    org/jruby/ext/zlib/JZlibRubyGzipReader.java:582:in `eof?'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:1183:in `auto_io'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:447:in `content_encoding_gunzip'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:830:in `response_content_encoding'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize/http/agent.rb:296:in `fetch'
    /home/travis/build/sparklemotion/mechanize/lib/mechanize.rb:464:in `get'
    /home/travis/build/sparklemotion/mechanize/test/test_mechanize.rb:569:in `test_content_encoding_hooks_header'

```

</details>