### PR TITLE
Add support for Basic auth without realms as described in RFC 7235

### DIFF
--- a/lib/mechanize/http/www_authenticate_parser.rb
+++ b/lib/mechanize/http/www_authenticate_parser.rb
@@ -51,9 +51,19 @@ class Mechanize::HTTP::WWWAuthenticateParser
         scheme.capitalize!
       end
 
-      next unless space
-
       params = {}
+
+      # Handles 'Basic' auth without realms
+      # https://tools.ietf.org/html/rfc7235#appendix-A
+      #   > The "realm" parameter is no longer always required on challenges;
+      unless space
+        if scheme == 'Basic'
+          challenge.params = params
+          challenge.raw = www_authenticate[start, @scanner.pos]
+          challenges << challenge
+        end
+        next
+      end
 
       while true do
         pos = @scanner.pos

--- a/test/test_mechanize_http_www_authenticate_parser.rb
+++ b/test/test_mechanize_http_www_authenticate_parser.rb
@@ -101,6 +101,14 @@ class TestMechanizeHttpWwwAuthenticateParser < Mechanize::TestCase
     assert_equal expected, @parser.parse('NTLM foo=')
   end
 
+  def test_parse_no_realm
+    expected = [
+      challenge('Basic', {}, 'Basic'),
+    ]
+
+    assert_equal expected, @parser.parse('Basic')
+  end
+
   def test_parse_realm_uppercase
     expected = [
       challenge('Basic', { 'realm' => 'foo' }, 'Basic ReAlM=foo'),


### PR DESCRIPTION
From [RFC 7235 Appendix A](https://tools.ietf.org/html/rfc7235#appendix-A):

> The "realm" parameter is no longer always required on challenges;
  consequently, the ABNF allows challenges without any auth parameters.

This patch makes the 'realm' parameter optional for Basic auth.

Having said that, I'm not too sure whether this would be in conflict with [RFC 7617 section 2.](https://tools.ietf.org/html/rfc7617#section-2) where it says the following about Basic auth:

> The authentication parameter 'realm' is REQUIRED ([[RFC7235],
      Section 2.2](https://tools.ietf.org/html/rfc7235#section-2.2)).

Feel free to reject this PR if we'd rather keep to the words of RFC 7617 and/or I have misinterpreted RFC 7235.  Otherwise, comments and suggestions welcome if improvements needed.

- [Possibly relevant SO link](https://stackoverflow.com/a/35339784)