### PR TITLE
Add fallback to ISO 8601 date format in `ContentDispositionParser`.

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -10,6 +10,7 @@
   * Page::Link#uri now handles non-ASCII `href`s. (#569) @terryyin
   * FileConnection supports Windows drive letters (#483)
   * Credential headers 'Authorization' and 'Cookie' are deleted on cross-origin redirects. (#538) @kyoshidajp
+  * ContentDispositionParser handles ISO8601 date headers, to be robust with websites that ignore RFC2183. (#554) @reitermarkus
 
 * Bug fix
   * POST headers 'Content-Length', 'Content-MD5', and 'Content-Type' are deleted in a case-insensitive manner on redirects. Previously these headers were treated as case-sensitive.

--- a/lib/mechanize/http/content_disposition_parser.rb
+++ b/lib/mechanize/http/content_disposition_parser.rb
@@ -17,6 +17,7 @@ end
 # * Missing disposition-type
 # * Multiple semicolons
 # * Whitespace around semicolons
+# * Dates in ISO 8601 format
 
 class Mechanize::HTTP::ContentDispositionParser
 
@@ -94,7 +95,17 @@ class Mechanize::HTTP::ContentDispositionParser
               when /^filename$/ then
                 rfc_2045_value
               when /^(creation|modification|read)-date$/ then
-                Time.rfc822 rfc_2045_quoted_string
+                date = rfc_2045_quoted_string
+
+                begin
+                  Time.rfc822 date
+                rescue ArgumentError
+                  begin
+                    Time.iso8601 date
+                  rescue ArgumentError
+                    nil
+                  end
+                end
               when /^size$/ then
                 rfc_2045_value.to_i(10)
               else

--- a/test/test_mechanize_http_content_disposition_parser.rb
+++ b/test/test_mechanize_http_content_disposition_parser.rb
@@ -30,6 +30,33 @@ class TestMechanizeHttpContentDispositionParser < Mechanize::TestCase
     assert_equal expected,     content_disposition.parameters
   end
 
+  def test_parse_date_iso8601_fallback
+    now = Time.at Time.now.to_i
+
+    content_disposition = @parser.parse \
+      'attachment;' \
+      'filename=value;' \
+      "creation-date=\"#{now.iso8601}\";" \
+      "modification-date=\"#{(now + 1).iso8601}\""
+
+    assert_equal 'attachment', content_disposition.type
+    assert_equal 'value',      content_disposition.filename
+    assert_equal now,          content_disposition.creation_date
+    assert_equal((now + 1),    content_disposition.modification_date)
+  end
+
+  def test_parse_date_invalid
+    now = Time.at Time.now.to_i
+
+    content_disposition = @parser.parse \
+      'attachment;' \
+      'filename=value;' \
+      "creation-date=\"#{now.to_s}\";" \
+      "modification-date=\"#{(now + 1).to_s}\""
+
+    assert_nil content_disposition
+  end
+
   def test_parse_header
     content_disposition = @parser.parse \
       'content-disposition: attachment;filename=value', true


### PR DESCRIPTION
Some websites incorrectly use ISO 8601 for the dates, causing an exception to be raised and rendering all other correctly specified fields unusable.