### PR TITLE
Add Webrick as runtime dependency

### DIFF
--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "http-cookie",          [ "~> 1.0" ]
   spec.add_runtime_dependency "nokogiri",             [ "~> 1.6" ]
   spec.add_runtime_dependency "ntlm-http",            [ ">= 0.1.1", "~> 0.1"   ]
+  spec.add_runtime_dependency "webrick",              [ "~> 1.7" ]
   spec.add_runtime_dependency "webrobots",            [ "< 0.2",    ">= 0.0.9" ]
   spec.add_runtime_dependency "domain_name",          [ ">= 0.5.1", "~> 0.5"   ]
 end


### PR DESCRIPTION
Ruby >= 3.0 no longer includes Webrick as a standard gem so it will require declaring as a dependency.