### PR TITLE
test: conditionally skip depending on net-http-persistent < v4

### DIFF
--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -1056,6 +1056,11 @@ but not <a href="/" rel="me nofollow">this</a>!
   end
 
   def test_retry_change_requests_equals
+    unless Gem::Requirement.new("< 4.0.0").satisfied_by?(Gem::Version.new(Net::HTTP::Persistent::VERSION))
+      # see https://github.com/drbrain/net-http-persistent/pull/100
+      skip("net-http-persistent 4.0.0 and later does not support retry_change_requests")
+    end
+
     refute @mech.retry_change_requests
 
     @mech.retry_change_requests = true

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1590,6 +1590,11 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
   end
 
   def test_retry_change_request_equals
+    unless Gem::Requirement.new("< 4.0.0").satisfied_by?(Gem::Version.new(Net::HTTP::Persistent::VERSION))
+      # see https://github.com/drbrain/net-http-persistent/pull/100
+      skip("net-http-persistent 4.0.0 and later does not support retry_change_requests")
+    end
+
     refute @agent.http.retry_change_requests
 
     @agent.retry_change_requests = true


### PR DESCRIPTION
Net::HTTP::Persistent removed `#retry_change_requests` in v4.0.0 and
later, so these tests fail if we've pulled in a more recent version
than that.

Related to https://github.com/drbrain/net-http-persistent/pull/100