### PR TITLE
ci: update the travis testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,15 @@ before_install:
 
 matrix:
   include:
-    - rvm: 2.3.8
-    - rvm: 2.4.5
-    - rvm: 2.5.3
+    - rvm: 2.5.8
+    - rvm: 2.6.5
+    - rvm: 2.7.2
+    - rvm: 3.0.0
     - rvm: ruby-head
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.14.0
     - rvm: jruby-head
   allow_failures:
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.14.0
     - rvm: jruby-head
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
   - knu@idaemons.org
 
 before_install:
-  - gem install --conservative bundler -v'< 2'
+  - gem install --conservative bundler -v '~> 2.2'
 
 matrix:
   include:


### PR DESCRIPTION
- add ruby 2.6, 2.7, and 3.0
- remove 2.4 and 2.3
- update to a modern bundler (~> 2.2)

I expect these tests will fail because #558 has not been merged yet.
