### PR TITLE
use addressable gem to escape uri with fragment properly

### DIFF
--- a/lib/mechanize/page/link.rb
+++ b/lib/mechanize/page/link.rb
@@ -96,7 +96,11 @@ class Mechanize::Page::Link
                begin
                  URI.parse @href
                rescue URI::InvalidURIError
-                 URI.parse Addressable::URI.escape @href
+                 begin
+                   URI.parse Addressable::URI.escape @href
+                 rescue Addressable::URI::InvalidURIError
+                   raise URI::InvalidURIError
+                 end
                end
              end
   end

--- a/lib/mechanize/page/link.rb
+++ b/lib/mechanize/page/link.rb
@@ -8,6 +8,8 @@
 #   <a href="http://example">Hello World</a>
 #   <a href="http://example"><img src="test.jpg" alt="Hello World"></a>
 
+require 'addressable/uri'
+
 class Mechanize::Page::Link
   attr_reader :node
   attr_reader :href
@@ -94,7 +96,7 @@ class Mechanize::Page::Link
                begin
                  URI.parse @href
                rescue URI::InvalidURIError
-                 URI.parse WEBrick::HTTPUtils.escape @href
+                 URI.parse Addressable::URI.escape @href
                end
              end
   end

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -59,4 +59,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "webrobots",            [ "< 0.2",    ">= 0.0.9" ]
   spec.add_runtime_dependency "domain_name",          [ ">= 0.5.1", "~> 0.5"   ]
   spec.add_runtime_dependency 'webrick', "~> 1.7"
+  spec.add_runtime_dependency 'addressable', "~> 2.7"
 end

--- a/test/test_mechanize_link.rb
+++ b/test/test_mechanize_link.rb
@@ -146,6 +146,19 @@ class TestMechanizeLink < Mechanize::TestCase
     assert_equal '%D1%83%D0%B2%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5', link.uri.fragment
   end
 
+  def test_bad_uri_raise_compatible_exception
+    doc = Nokogiri::HTML::Document.new
+
+    node = Nokogiri::XML::Node.new('foo', doc)
+    node['href'] = 'http://http:foo.bar/ baz'
+
+    link = Mechanize::Page::Link.new(node, nil, nil)
+
+    assert_raises URI::InvalidURIError do
+      link.uri
+    end
+  end
+
   def test_resolving_full_uri
     page = @mech.get("http://localhost/frame_test.html")
     link = page.link_with(:text => "Form Test")

--- a/test/test_mechanize_link.rb
+++ b/test/test_mechanize_link.rb
@@ -135,6 +135,17 @@ class TestMechanizeLink < Mechanize::TestCase
     assert_equal 'http://foo.bar/%20baz', link.uri.to_s
   end
 
+  def test_uri_weird_with_fragment
+    doc = Nokogiri::HTML::Document.new
+
+    node = Nokogiri::XML::Node.new('foo', doc)
+    node['href'] = 'http://foo.bar/ baz#уважение'
+
+    link = Mechanize::Page::Link.new(node, nil, nil)
+
+    assert_equal '%D1%83%D0%B2%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5', link.uri.fragment
+  end
+
   def test_resolving_full_uri
     page = @mech.get("http://localhost/frame_test.html")
     link = page.link_with(:text => "Form Test")


### PR DESCRIPTION
When the fragment (part that's after `#`) contains characters that need to be escaped, `WEBrick::HTTPUtils.escape` will wrongly escape the `#` as well. That will break the original uri. The Addressable gem can do the escape properly.