### PR TITLE
drop support for EOLed Ruby, add rubocop security checks, update dependencies, frozen string literals

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "jruby"]
+        ruby-version: ["2.5", "2.6", "2.7", "3.0", "jruby"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rdoc
+++ b/README.rdoc
@@ -13,7 +13,7 @@ a history.
 
 == Dependencies
 
-* ruby 1.9.2 or newer
+* ruby 2.5 or newer
 * nokogiri[https://github.com/sparklemotion/nokogiri]
 
 == Support:

--- a/Rakefile
+++ b/Rakefile
@@ -38,4 +38,9 @@ task publish_docs: %w[rdoc] do
   sh 'rsync', '-avzO', '--delete', 'doc/', 'docs-push.seattlerb.org:/data/www/docs.seattlerb.org/mechanize/'
 end
 
-task default: :test
+desc "Run rubocop security check"
+task :rubocop_security do
+  sh "rubocop lib --only Security"
+end
+
+task default: [:rubocop_security, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -38,9 +38,19 @@ task publish_docs: %w[rdoc] do
   sh 'rsync', '-avzO', '--delete', 'doc/', 'docs-push.seattlerb.org:/data/www/docs.seattlerb.org/mechanize/'
 end
 
-desc "Run rubocop security check"
-task :rubocop_security do
-  sh "rubocop lib --only Security"
+desc "Run rubocop checks"
+task :rubocop => ["rubocop:security", "rubocop:frozen_string_literals"]
+
+namespace "rubocop" do
+  desc "Run rubocop security check"
+  task :security do
+    sh "rubocop lib --only Security"
+  end
+
+  desc "Run rubocop string literals check"
+  task :frozen_string_literals do
+    sh "rubocop lib --auto-correct-all --only Style/FrozenStringLiteralComment"
+  end
 end
 
-task default: [:rubocop_security, :test]
+task default: [:rubocop, :test]

--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/version'
 require 'fileutils'
 require 'forwardable'

--- a/lib/mechanize/chunked_termination_error.rb
+++ b/lib/mechanize/chunked_termination_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Raised when Mechanize detects the chunked transfer-encoding may be
 # incorrectly terminated.

--- a/lib/mechanize/content_type_error.rb
+++ b/lib/mechanize/content_type_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This error is raised when a pluggable parser tries to parse a content type
 # that it does not know how to handle.  For example if Mechanize::Page were to

--- a/lib/mechanize/cookie.rb
+++ b/lib/mechanize/cookie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 warn 'mechanize/cookie will be deprecated.  Please migrate to the http-cookie APIs.' if $VERBOSE
 
 require 'http/cookie'

--- a/lib/mechanize/cookie.rb
+++ b/lib/mechanize/cookie.rb
@@ -50,19 +50,6 @@ class Mechanize
 
   Cookie = ::HTTP::Cookie
 
-  # Compatibility for Ruby 1.8/1.9
-  unless Cookie.respond_to?(:prepend, true)
-    require 'mechanize/prependable'
-
-    class Cookie
-      extend Prependable
-
-      class << self
-        extend Prependable
-      end
-    end
-  end
-
   class Cookie
     prepend CookieIMethods
 

--- a/lib/mechanize/cookie_jar.rb
+++ b/lib/mechanize/cookie_jar.rb
@@ -148,7 +148,7 @@ class Mechanize
       return super(input, opthash) if opthash[:format] != :yaml
 
       begin
-        data = YAML.load(input)
+        data = YAML.load(input) # rubocop:disable Security/YAMLLoad
       rescue ArgumentError
         @logger.warn "unloadable YAML cookie data discarded" if @logger
         return self

--- a/lib/mechanize/cookie_jar.rb
+++ b/lib/mechanize/cookie_jar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 warn 'mechanize/cookie_jar will be deprecated.  Please migrate to the http-cookie APIs.' if $VERBOSE
 
 require 'http/cookie_jar'

--- a/lib/mechanize/cookie_jar.rb
+++ b/lib/mechanize/cookie_jar.rb
@@ -175,15 +175,6 @@ class Mechanize
     end
   end
 
-  # Compatibility for Ruby 1.8/1.9
-  unless ::HTTP::CookieJar.respond_to?(:prepend, true)
-    require 'mechanize/prependable'
-
-    class ::HTTP::CookieJar
-      extend Prependable
-    end
-  end
-
   class ::HTTP::CookieJar
     prepend CookieJarIMethods
   end

--- a/lib/mechanize/directory_saver.rb
+++ b/lib/mechanize/directory_saver.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Unlike Mechanize::FileSaver, the directory saver places all downloaded files
 # in a single pre-specified directory.

--- a/lib/mechanize/download.rb
+++ b/lib/mechanize/download.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Download is a pluggable parser for downloading files without loading them
 # into memory first.  You may subclass this class to handle content types you

--- a/lib/mechanize/element_matcher.rb
+++ b/lib/mechanize/element_matcher.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mechanize::ElementMatcher
 
   def elements_with singular, plural = "#{singular}s"

--- a/lib/mechanize/element_not_found_error.rb
+++ b/lib/mechanize/element_not_found_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Raised when an an element was not found on the Page
 

--- a/lib/mechanize/file.rb
+++ b/lib/mechanize/file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This is the base class for the Pluggable Parsers.  If Mechanize cannot find
 # an appropriate class to use for the content type, this class will be used.

--- a/lib/mechanize/file_connection.rb
+++ b/lib/mechanize/file_connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Wrapper to make a file URI work like an http URI
 

--- a/lib/mechanize/file_request.rb
+++ b/lib/mechanize/file_request.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # A wrapper for a file URI that makes a request that works like a
 # Net::HTTPRequest

--- a/lib/mechanize/file_response.rb
+++ b/lib/mechanize/file_response.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Fake response for dealing with file:/// requests
 

--- a/lib/mechanize/file_saver.rb
+++ b/lib/mechanize/file_saver.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This is a pluggable parser that automatically saves every file it
 # encounters.  Unlike Mechanize::DirectorySaver, the file saver saves the

--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/element_matcher'
 
 # This class encapsulates a form parsed out of an HTML page.  Each type of

--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -643,15 +643,6 @@ class Mechanize::Form
     end
   end
 
-  unless ::String.method_defined?(:b)
-    # Define String#b for Ruby < 2.0
-    class ::String
-      def b
-        dup.force_encoding(Encoding::ASCII_8BIT)
-      end
-    end
-  end
-
   def rand_string(len = 10)
     chars = ("a".."z").to_a + ("A".."Z").to_a
     string = ::String.new

--- a/lib/mechanize/form/button.rb
+++ b/lib/mechanize/form/button.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # A Submit button in a Form
 

--- a/lib/mechanize/form/check_box.rb
+++ b/lib/mechanize/form/check_box.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class represents a check box found in a Form.  To activate the CheckBox
 # in the Form, set the checked method to true.

--- a/lib/mechanize/form/field.rb
+++ b/lib/mechanize/form/field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class represents a field in a form.  It handles the following input
 # tags found in a form:

--- a/lib/mechanize/form/file_upload.rb
+++ b/lib/mechanize/form/file_upload.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This class represents a file upload field found in a form.  To use this
 # class, set FileUpload#file_data= to the data of the file you want to upload
 # and FileUpload#mime_type= to the appropriate mime type of the file.

--- a/lib/mechanize/form/hidden.rb
+++ b/lib/mechanize/form/hidden.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::Form::Hidden < Mechanize::Form::Field
 end
 

--- a/lib/mechanize/form/image_button.rb
+++ b/lib/mechanize/form/image_button.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class represents an image button in a form.  Use the x and y methods to
 # set the x and y positions for where the mouse "clicked".

--- a/lib/mechanize/form/keygen.rb
+++ b/lib/mechanize/form/keygen.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class represents a keygen (public / private key generator) found in a
 # Form. The field will automatically generate a key pair and compute its own

--- a/lib/mechanize/form/multi_select_list.rb
+++ b/lib/mechanize/form/multi_select_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class represents a select list where multiple values can be selected.
 # MultiSelectList#value= accepts an array, and those values are used as

--- a/lib/mechanize/form/option.rb
+++ b/lib/mechanize/form/option.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class contains an option found within SelectList.  A SelectList can
 # have many Option classes associated with it.  An option can be selected by

--- a/lib/mechanize/form/radio_button.rb
+++ b/lib/mechanize/form/radio_button.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class represents a radio button found in a Form.  To activate the
 # RadioButton in the Form, set the checked method to true.

--- a/lib/mechanize/form/reset.rb
+++ b/lib/mechanize/form/reset.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::Form::Reset < Mechanize::Form::Button
 end
 

--- a/lib/mechanize/form/select_list.rb
+++ b/lib/mechanize/form/select_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This class represents a select list or drop down box in a Form.  Set the
 # value for the list by calling SelectList#value=.  SelectList contains a list
 # of Option that were found.  After finding the correct option, set the select

--- a/lib/mechanize/form/submit.rb
+++ b/lib/mechanize/form/submit.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::Form::Submit < Mechanize::Form::Button
 end
 

--- a/lib/mechanize/form/text.rb
+++ b/lib/mechanize/form/text.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::Form::Text < Mechanize::Form::Field
 end
 

--- a/lib/mechanize/form/textarea.rb
+++ b/lib/mechanize/form/textarea.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::Form::Textarea < Mechanize::Form::Field
 end
 

--- a/lib/mechanize/headers.rb
+++ b/lib/mechanize/headers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::Headers < Hash
   def [](key)
     super(key.downcase)

--- a/lib/mechanize/history.rb
+++ b/lib/mechanize/history.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class manages history for your mechanize object.
 

--- a/lib/mechanize/http.rb
+++ b/lib/mechanize/http.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Mechanize::HTTP contains classes for communicated with HTTP servers.  All
 # API under this namespace is considered private and is subject to change at

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -839,7 +839,7 @@ class Mechanize::HTTP::Agent
 
     out_io
   rescue Zlib::Error => e
-    message = "error handling content-encoding #{response['Content-Encoding']}:"
+    message = String.new("error handling content-encoding #{response['Content-Encoding']}:")
     message << " #{e.message} (#{e.class})"
     raise Mechanize::Error, message
   ensure

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'tempfile'
 require 'net/ntlm'
 require 'kconv'

--- a/lib/mechanize/http/auth_challenge.rb
+++ b/lib/mechanize/http/auth_challenge.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::HTTP
 
   AuthChallenge = Struct.new :scheme, :params, :raw

--- a/lib/mechanize/http/auth_realm.rb
+++ b/lib/mechanize/http/auth_realm.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::HTTP::AuthRealm
 
   attr_reader :scheme

--- a/lib/mechanize/http/auth_store.rb
+++ b/lib/mechanize/http/auth_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # A credential store for HTTP authentication.
 #

--- a/lib/mechanize/http/content_disposition_parser.rb
+++ b/lib/mechanize/http/content_disposition_parser.rb
@@ -126,7 +126,7 @@ class Mechanize::HTTP::ContentDispositionParser
   def rfc_2045_quoted_string
     return nil unless @scanner.scan(/"/)
 
-    text = ''
+    text = String.new
 
     while true do
       chunk = @scanner.scan(/[\000-\014\016-\041\043-\133\135-\177]+/) # not \r "

--- a/lib/mechanize/http/content_disposition_parser.rb
+++ b/lib/mechanize/http/content_disposition_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # coding: BINARY
 
 require 'strscan'

--- a/lib/mechanize/http/www_authenticate_parser.rb
+++ b/lib/mechanize/http/www_authenticate_parser.rb
@@ -151,10 +151,10 @@ class Mechanize::HTTP::WWWAuthenticateParser
   def quoted_string
     return nil unless @scanner.scan(/"/)
 
-    text = ''
+    text = String.new
 
     while true do
-      chunk = @scanner.scan(/[\r\n \t\041\043-\176\200-\377]+/) # not "
+      chunk = @scanner.scan(/[\r\n \t\x21\x23-\x7e\u0080-\u00ff]+/) # not " which is \x22
 
       if chunk then
         text << chunk

--- a/lib/mechanize/http/www_authenticate_parser.rb
+++ b/lib/mechanize/http/www_authenticate_parser.rb
@@ -1,4 +1,4 @@
-# coding: BINARY
+# frozen_string_literal: true
 
 require 'strscan'
 

--- a/lib/mechanize/image.rb
+++ b/lib/mechanize/image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # An Image holds downloaded data for an image/* response.
 

--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class encapsulates an HTML page.  If Mechanize finds a content
 # type of 'text/html', this class will be instantiated and returned.

--- a/lib/mechanize/page/base.rb
+++ b/lib/mechanize/page/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # A base element on an HTML page.  Mechanize treats base tags just like 'a'
 # tags.  Base objects will contain links, but most likely will have no text.

--- a/lib/mechanize/page/frame.rb
+++ b/lib/mechanize/page/frame.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # A Frame object wraps a frame HTML element.  Frame objects can be treated
 # just like Link objects.  They contain #src, the #link they refer to and a
 # #name, the name of the frame they refer to.  #src and #name are aliased to

--- a/lib/mechanize/page/image.rb
+++ b/lib/mechanize/page/image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # An image element on an HTML page
 

--- a/lib/mechanize/page/label.rb
+++ b/lib/mechanize/page/label.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # A form label on an HTML page
 

--- a/lib/mechanize/page/link.rb
+++ b/lib/mechanize/page/link.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class encapsulates links.  It contains the text and the URI for
 # 'a' tags parsed out of an HTML page.  If the link contains an image,

--- a/lib/mechanize/page/meta_refresh.rb
+++ b/lib/mechanize/page/meta_refresh.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class encapsulates a meta element with a refresh http-equiv.  Mechanize
 # treats meta refresh elements just like 'a' tags.  MetaRefresh objects will

--- a/lib/mechanize/parser.rb
+++ b/lib/mechanize/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # The parser module provides standard methods for accessing the headers and
 # content of a response that are shared across pluggable parsers.

--- a/lib/mechanize/pluggable_parsers.rb
+++ b/lib/mechanize/pluggable_parsers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/file'
 require 'mechanize/file_saver'
 require 'mechanize/page'

--- a/lib/mechanize/prependable.rb
+++ b/lib/mechanize/prependable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Fake implementation of prepend(), which does not support overriding
 # inherited methods nor methods that are formerly overridden by
 # another invocation of prepend().

--- a/lib/mechanize/redirect_limit_reached_error.rb
+++ b/lib/mechanize/redirect_limit_reached_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Raised when too many redirects are sent
 

--- a/lib/mechanize/redirect_not_get_or_head_error.rb
+++ b/lib/mechanize/redirect_not_get_or_head_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Raised when a POST, PUT, or DELETE request results in a redirect
 # see RFC 2616 10.3.2, 10.3.3 http://www.ietf.org/rfc/rfc2616.txt

--- a/lib/mechanize/response_code_error.rb
+++ b/lib/mechanize/response_code_error.rb
@@ -17,7 +17,7 @@ class Mechanize::ResponseCodeError < Mechanize::Error
 
   def to_s
     response_class = Net::HTTPResponse::CODE_TO_OBJ[@response_code]
-    out = "#{@response_code} => #{response_class} "
+    out = String.new("#{@response_code} => #{response_class} ")
     out << "for #{@page.uri} " if @page.respond_to? :uri # may be HTTPResponse
     out << "-- #{super}"
   end

--- a/lib/mechanize/response_code_error.rb
+++ b/lib/mechanize/response_code_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This error is raised when Mechanize encounters a response code it does not
 # know how to handle.  Currently, this exception will be thrown if Mechanize
 # encounters response codes other than 200, 301, or 302.  Any other response

--- a/lib/mechanize/response_read_error.rb
+++ b/lib/mechanize/response_read_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Raised when Mechanize encounters an error while reading the response body
 # from the server.  Contains the response headers and the response body up to

--- a/lib/mechanize/robots_disallowed_error.rb
+++ b/lib/mechanize/robots_disallowed_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Exception that is raised when an access to a resource is disallowed by
 # robots.txt or by HTML document itself.
 

--- a/lib/mechanize/test_case.rb
+++ b/lib/mechanize/test_case.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize'
 require 'logger'
 require 'tempfile'

--- a/lib/mechanize/test_case.rb
+++ b/lib/mechanize/test_case.rb
@@ -58,12 +58,12 @@ class Mechanize::TestCase < Minitest::Test
 
   def fake_page agent = @mech
     uri = URI 'http://fake.example/'
-    html = <<-END
-<html>
-<body>
-<form><input type="submit" value="submit" /></form>
-</body>
-</html>
+    html = String.new(<<~END)
+      <html>
+      <body>
+      <form><input type="submit" value="submit" /></form>
+      </body>
+      </html>
     END
 
     Mechanize::Page.new uri, nil, html, 200, agent
@@ -125,7 +125,7 @@ class Mechanize::TestCase < Minitest::Test
   # Creates a Mechanize::Page for the given +uri+ with the given
   # +content_type+, response +body+ and HTTP status +code+
 
-  def page uri, content_type = 'text/html', body = '', code = 200
+  def page uri, content_type = 'text/html', body = String.new, code = 200
     uri = URI uri unless URI::Generic === uri
 
     Mechanize::Page.new(uri, { 'content-type' => content_type }, body, code,
@@ -313,7 +313,7 @@ class Response # :nodoc:
 
     def initialize
       @header = {}
-      @body = ''
+      @body = String.new
       @code = nil
       @query = nil
       @cookies = []

--- a/lib/mechanize/test_case/bad_chunking_servlet.rb
+++ b/lib/mechanize/test_case/bad_chunking_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class BadChunkingServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET req, res
     res.keep_alive = false if res.respond_to? :keep_alive=

--- a/lib/mechanize/test_case/basic_auth_servlet.rb
+++ b/lib/mechanize/test_case/basic_auth_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class BasicAuthServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req,res)
     htpd = nil

--- a/lib/mechanize/test_case/content_type_servlet.rb
+++ b/lib/mechanize/test_case/content_type_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ContentTypeServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     ct = req.query['ct'] || "text/html; charset=utf-8"

--- a/lib/mechanize/test_case/digest_auth_servlet.rb
+++ b/lib/mechanize/test_case/digest_auth_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'logger'
 
 class DigestAuthServlet < WEBrick::HTTPServlet::AbstractServlet

--- a/lib/mechanize/test_case/file_upload_servlet.rb
+++ b/lib/mechanize/test_case/file_upload_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class FileUploadServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_POST req, res
     res.body = req.body

--- a/lib/mechanize/test_case/form_servlet.rb
+++ b/lib/mechanize/test_case/form_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class FormServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     res.content_type = 'text/html'

--- a/lib/mechanize/test_case/gzip_servlet.rb
+++ b/lib/mechanize/test_case/gzip_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'stringio'
 require 'zlib'
 

--- a/lib/mechanize/test_case/header_servlet.rb
+++ b/lib/mechanize/test_case/header_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class HeaderServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     res.content_type = "text/plain"

--- a/lib/mechanize/test_case/http_refresh_servlet.rb
+++ b/lib/mechanize/test_case/http_refresh_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class HttpRefreshServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     res['Content-Type'] = req.query['ct'] || "text/html"

--- a/lib/mechanize/test_case/infinite_redirect_servlet.rb
+++ b/lib/mechanize/test_case/infinite_redirect_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class InfiniteRedirectServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     res['Content-Type'] = req.query['ct'] || "text/html"

--- a/lib/mechanize/test_case/infinite_refresh_servlet.rb
+++ b/lib/mechanize/test_case/infinite_refresh_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class InfiniteRefreshServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     address = "#{req.host}:#{req.port}"

--- a/lib/mechanize/test_case/many_cookies_as_string_servlet.rb
+++ b/lib/mechanize/test_case/many_cookies_as_string_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ManyCookiesAsStringServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     cookies = []

--- a/lib/mechanize/test_case/many_cookies_servlet.rb
+++ b/lib/mechanize/test_case/many_cookies_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ManyCookiesServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     name_cookie = WEBrick::Cookie.new("name", "Aaron")

--- a/lib/mechanize/test_case/modified_since_servlet.rb
+++ b/lib/mechanize/test_case/modified_since_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ModifiedSinceServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     s_time = 'Fri, 04 May 2001 00:00:38 GMT'

--- a/lib/mechanize/test_case/ntlm_servlet.rb
+++ b/lib/mechanize/test_case/ntlm_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class NTLMServlet < WEBrick::HTTPServlet::AbstractServlet
 
   def do_GET(req, res)

--- a/lib/mechanize/test_case/one_cookie_no_spaces_servlet.rb
+++ b/lib/mechanize/test_case/one_cookie_no_spaces_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class OneCookieNoSpacesServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     cookie = WEBrick::Cookie.new("foo", "bar")

--- a/lib/mechanize/test_case/one_cookie_servlet.rb
+++ b/lib/mechanize/test_case/one_cookie_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class OneCookieServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     cookie = WEBrick::Cookie.new("foo", "bar")

--- a/lib/mechanize/test_case/quoted_value_cookie_servlet.rb
+++ b/lib/mechanize/test_case/quoted_value_cookie_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class QuotedValueCookieServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     cookie = WEBrick::Cookie.new("quoted", "\"value\"")

--- a/lib/mechanize/test_case/redirect_servlet.rb
+++ b/lib/mechanize/test_case/redirect_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RedirectServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     res['Content-Type'] = req.query['ct'] || 'text/html'

--- a/lib/mechanize/test_case/referer_servlet.rb
+++ b/lib/mechanize/test_case/referer_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RefererServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     res['Content-Type'] = "text/html"

--- a/lib/mechanize/test_case/refresh_with_empty_url.rb
+++ b/lib/mechanize/test_case/refresh_with_empty_url.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RefreshWithEmptyUrl < WEBrick::HTTPServlet::AbstractServlet
   @@count = 0
   def do_GET(req, res)

--- a/lib/mechanize/test_case/refresh_without_url.rb
+++ b/lib/mechanize/test_case/refresh_without_url.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RefreshWithoutUrl < WEBrick::HTTPServlet::AbstractServlet
   @@count = 0
   def do_GET(req, res)

--- a/lib/mechanize/test_case/response_code_servlet.rb
+++ b/lib/mechanize/test_case/response_code_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ResponseCodeServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     res['Content-Type'] = req.query['ct'] || "text/html"

--- a/lib/mechanize/test_case/robots_txt_servlet.rb
+++ b/lib/mechanize/test_case/robots_txt_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RobotsTxtServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     if /301/ === req['Host'] && req.path == '/robots.txt'

--- a/lib/mechanize/test_case/send_cookies_servlet.rb
+++ b/lib/mechanize/test_case/send_cookies_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SendCookiesServlet < WEBrick::HTTPServlet::AbstractServlet
   def do_GET(req, res)
     res.content_type = 'text/html'

--- a/lib/mechanize/test_case/server.rb
+++ b/lib/mechanize/test_case/server.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'webrick'
 require 'mechanize/test_case/servlets'
 

--- a/lib/mechanize/test_case/servlets.rb
+++ b/lib/mechanize/test_case/servlets.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case/bad_chunking_servlet'
 require 'mechanize/test_case/basic_auth_servlet'
 require 'mechanize/test_case/content_type_servlet'

--- a/lib/mechanize/test_case/verb_servlet.rb
+++ b/lib/mechanize/test_case/verb_servlet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class VerbServlet < WEBrick::HTTPServlet::AbstractServlet
   %w[HEAD GET POST PUT DELETE].each do |verb|
     define_method "do_#{verb}" do |req, res|

--- a/lib/mechanize/unauthorized_error.rb
+++ b/lib/mechanize/unauthorized_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::UnauthorizedError < Mechanize::ResponseCodeError
 
   attr_reader :challenges

--- a/lib/mechanize/unsupported_scheme_error.rb
+++ b/lib/mechanize/unsupported_scheme_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize::UnsupportedSchemeError < Mechanize::Error
   attr_accessor :scheme, :uri
 

--- a/lib/mechanize/util.rb
+++ b/lib/mechanize/util.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'cgi'
 require 'nkf'
 

--- a/lib/mechanize/util.rb
+++ b/lib/mechanize/util.rb
@@ -16,7 +16,7 @@ class Mechanize::Util
     def build_query_string(parameters, enc = nil)
       each_parameter(parameters).inject(nil) { |s, (k, v)|
         # WEBrick::HTTP.escape* has some problems about m17n on ruby-1.9.*.
-        (s.nil? ? '' : s << '&') << [CGI.escape(k.to_s), CGI.escape(v.to_s)].join('=')
+        (s.nil? ? String.new : s << '&') << [CGI.escape(k.to_s), CGI.escape(v.to_s)].join('=')
       } || ''
     end
 

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Mechanize
   VERSION = "2.7.7"
 end

--- a/lib/mechanize/xml_file.rb
+++ b/lib/mechanize/xml_file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # This class encapsulates an XML file. If Mechanize finds a content-type
 # of 'text/xml' or 'application/xml' this class will be instantiated and

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -56,4 +56,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("webrobots", ["< 0.2", ">= 0.0.9"])
   spec.add_runtime_dependency('addressable', "~> 2.7")
   spec.add_runtime_dependency('webrick', "~> 1.7")
+
+  spec.add_development_dependency("rubocop", "~> 1.7")
 end

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -1,20 +1,21 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'mechanize/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "mechanize"
-  spec.version       = Mechanize::VERSION
-  spec.homepage      = "http://docs.seattlerb.org/mechanize/"
-  spec.summary       = %q{The Mechanize library is used for automating interaction with websites}
-  spec.description   =
+  spec.name = "mechanize"
+  spec.version = Mechanize::VERSION
+  spec.homepage = "http://docs.seattlerb.org/mechanize/"
+  spec.summary = 'The Mechanize library is used for automating interaction with websites'
+  spec.description =
     [
       "The Mechanize library is used for automating interaction with websites.",
       "Mechanize automatically stores and sends cookies, follows redirects,",
       "and can follow links and submit forms.  Form fields can be populated and",
       "submitted.  Mechanize also keeps track of the sites that you have visited as",
-      "a history."
+      "a history.",
     ].join("\n")
 
   spec.authors =
@@ -23,7 +24,7 @@ Gem::Specification.new do |spec|
       'Aaron Patterson',
       'Mike Dalessio',
       'Akinori MUSHA',
-      'Lee Jarvis'
+      'Lee Jarvis',
     ]
   spec.email =
     [
@@ -31,33 +32,28 @@ Gem::Specification.new do |spec|
       'aaron.patterson@gmail.com',
       'mike.dalessio@gmail.com',
       'knu@idaemons.org',
-      'ljjarvis@gmail.com'
+      'ljjarvis@gmail.com',
     ]
 
-  spec.license           = "MIT"
+  spec.license = "MIT"
 
   spec.require_paths = ["lib"]
-  spec.files         = `git ls-files`.split($/)
-  spec.test_files    = spec.files.grep(%r{^test/})
+  spec.files = %x(git ls-files).split($/)
+  spec.test_files = spec.files.grep(%r{^test/})
 
   spec.extra_rdoc_files += Dir['*.rdoc']
-  spec.rdoc_options     = ["--main", "README.rdoc"]
+  spec.rdoc_options = ["--main", "README.rdoc"]
 
-  spec.required_ruby_version = ">= 1.9.2"
+  spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_runtime_dependency "net-http-digest_auth", [ ">= 1.1.1", "~> 1.1" ]
-  if RUBY_VERSION >= "2.0"
-    spec.add_runtime_dependency "mime-types", [ ">= 1.17.2" ]
-    spec.add_runtime_dependency "net-http-persistent", [ ">= 2.5.2"]
-  else
-    spec.add_runtime_dependency "mime-types", [ ">= 1.17.2", "< 3" ]
-    spec.add_runtime_dependency "net-http-persistent", [ ">= 2.5.2", "~> 2.5" ]
-  end
-  spec.add_runtime_dependency "http-cookie",          [ "~> 1.0" ]
-  spec.add_runtime_dependency "nokogiri",             [ "~> 1.6" ]
-  spec.add_runtime_dependency "ntlm-http",            [ ">= 0.1.1", "~> 0.1"   ]
-  spec.add_runtime_dependency "webrobots",            [ "< 0.2",    ">= 0.0.9" ]
-  spec.add_runtime_dependency "domain_name",          [ ">= 0.5.1", "~> 0.5"   ]
-  spec.add_runtime_dependency 'webrick', "~> 1.7"
-  spec.add_runtime_dependency 'addressable', "~> 2.7"
+  spec.add_runtime_dependency("domain_name", [">= 0.5.1", "~> 0.5"])
+  spec.add_runtime_dependency("http-cookie", ["~> 1.0"])
+  spec.add_runtime_dependency("mime-types", [">= 1.17.2"])
+  spec.add_runtime_dependency("net-http-digest_auth", [">= 1.1.1", "~> 1.1"])
+  spec.add_runtime_dependency("net-http-persistent", [">= 2.5.2"])
+  spec.add_runtime_dependency("nokogiri", ["~> 1.6"])
+  spec.add_runtime_dependency("ntlm-http", [">= 0.1.1", "~> 0.1"])
+  spec.add_runtime_dependency("webrobots", ["< 0.2", ">= 0.0.9"])
+  spec.add_runtime_dependency('addressable', "~> 2.7")
+  spec.add_runtime_dependency('webrick', "~> 1.7")
 end

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -46,16 +46,16 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_runtime_dependency("domain_name", [">= 0.5.1", "~> 0.5"])
-  spec.add_runtime_dependency("http-cookie", ["~> 1.0"])
-  spec.add_runtime_dependency("mime-types", [">= 1.17.2"])
-  spec.add_runtime_dependency("net-http-digest_auth", [">= 1.1.1", "~> 1.1"])
-  spec.add_runtime_dependency("net-http-persistent", [">= 2.5.2"])
-  spec.add_runtime_dependency("nokogiri", ["~> 1.6"])
-  spec.add_runtime_dependency("ntlm-http", [">= 0.1.1", "~> 0.1"])
-  spec.add_runtime_dependency("webrobots", ["< 0.2", ">= 0.0.9"])
-  spec.add_runtime_dependency('addressable', "~> 2.7")
-  spec.add_runtime_dependency('webrick', "~> 1.7")
+  spec.add_runtime_dependency("domain_name", ">= 0.5.20190701", "~> 0.5")
+  spec.add_runtime_dependency("http-cookie", ">= 1.0.3", "~> 1.0")
+  spec.add_runtime_dependency("mime-types", "~> 3.0")
+  spec.add_runtime_dependency("net-http-digest_auth", ">= 1.4.1", "~> 1.4")
+  spec.add_runtime_dependency("net-http-persistent", ">= 4.0.1", "~> 4.0")
+  spec.add_runtime_dependency("nokogiri", ">= 1.11.1", "~> 1.11")
+  spec.add_runtime_dependency("ntlm-http", ">= 0.1.1", "~> 0.1")
+  spec.add_runtime_dependency("webrobots", "~> 0.1.2")
+  spec.add_runtime_dependency("addressable", "~> 2.7")
+  spec.add_runtime_dependency("webrick", "~> 1.7")
 
-  spec.add_development_dependency("rubocop", "~> 1.7")
+  spec.add_development_dependency("rubocop", ">= 1.9.1", "~> 1.9")
 end

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -16,11 +16,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     @res.instance_variable_set :@code, 200
     @res.instance_variable_set :@header, {}
 
-    @headers = if RUBY_VERSION >= '2.0.0' then
-                 %w[accept accept-encoding user-agent]
-               else
-                 %w[accept user-agent]
-               end
+    @headers = %w[accept accept-encoding user-agent]
   end
 
   def auth_realm uri, scheme, type


### PR DESCRIPTION
Closes #563: remove support for Ruby < 2.5
Closes #564: add rubocop security checks
Closes #565: update gem dependency versions
Enable frozen string literals in all files.