### PR TITLE
gemspec: unclutter the requirement

### DIFF
--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -1,8 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'mechanize/version'
+require_relative 'lib/mechanize/version'
 
 Gem::Specification.new do |spec|
   spec.name = "mechanize"


### PR DESCRIPTION
`require_relative` is available since at least ruby 2.1 so not compatibility issue since mechanize require ruby 2.5+