### PR TITLE
ci: split out rubocop as an initial job

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,18 @@ on:
       - main
 
 jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.0"
+        bundler-cache: true
+    - run: bundle exec rake rubocop
+
   test:
+    needs: ["rubocop"]
     strategy:
       fail-fast: false
       matrix:
@@ -19,27 +30,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: ${{matrix.ruby-version}}
         bundler-cache: true
-    - name: Run tests
-      run: bundle exec rake
+    - run: bundle exec rake test
 
   test-platform:
+    needs: ["rubocop"]
     strategy:
       fail-fast: false
       matrix:
         platform: ["windows-latest", "macos-latest"]
 
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{matrix.platform}}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: "3.0"
         bundler-cache: true
-    - name: Run tests
-      run: bundle exec rake
+    - run: bundle exec rake test


### PR DESCRIPTION
The specific intention here is to be able to discern whether a failing job is due to rubocop or due to functional failures.