### PR TITLE
Support Net::HTTP::Persistent.write_timeout

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,5 +1,9 @@
 name: "ci"
 
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -8,6 +12,8 @@ on:
     types: [opened, synchronize]
     branches:
       - main
+  schedule:
+    - cron: "0 8 * * 5" # At 08:00 on Friday # https://crontab.guru/#0_8_*_*_5
 
 jobs:
   rubocop:
@@ -16,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.1"
+        ruby-version: "3.2"
         bundler-cache: true
     - run: bundle exec rake rubocop
 
@@ -25,7 +31,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "head", "jruby", "truffleruby-head"]
+        # TODO update jruby once 9.4.1.0 is out
+        # 9.4.0.0 is affected by https://github.com/jruby/jruby/issues/7481
+        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.3", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +56,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.1"
+        ruby-version: "3.2"
         bundler-cache: true
     - run: bundle exec rake test

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.4", "truffleruby-head"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "head", "jruby-9.4", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -5,6 +5,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 5" # At 08:00 on Friday # https://crontab.guru/#0_8_*_*_5
   push:
     branches:
       - main
@@ -12,8 +15,6 @@ on:
     types: [opened, synchronize]
     branches:
       - main
-  schedule:
-    - cron: "0 8 * * 5" # At 08:00 on Friday # https://crontab.guru/#0_8_*_*_5
 
 jobs:
   rubocop:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -31,9 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO update jruby once 9.4.1.0 is out
-        # 9.4.0.0 is affected by https://github.com/jruby/jruby/issues/7481
-        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.3", "truffleruby-head"]
+        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.4", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:
@@ -42,6 +40,7 @@ jobs:
       with:
         ruby-version: ${{matrix.ruby-version}}
         bundler-cache: true
+        bundler: 2.3.26 # https://github.com/rubygems/rubygems/issues/6435
     - run: bundle exec rake test
 
   test-platform:
@@ -58,4 +57,5 @@ jobs:
       with:
         ruby-version: "3.2"
         bundler-cache: true
+        bundler: latest
     - run: bundle exec rake test

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.0"
+        ruby-version: "3.1"
         bundler-cache: true
     - run: bundle exec rake rubocop
 
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.5", "2.6", "2.7", "3.0", "jruby", "truffleruby-head"]
+        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "head", "jruby", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +48,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.0"
+        ruby-version: "3.1"
         bundler-cache: true
     - run: bundle exec rake test

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "head", "jruby-9.4", "truffleruby-head"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "jruby-9.4", "truffleruby", "head", "jruby-head", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.4", "truffleruby-head"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.4", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -19,7 +19,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.2"
@@ -35,7 +35,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby-version}}
@@ -52,7 +52,7 @@ jobs:
 
     runs-on: ${{matrix.platform}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "jruby-9.4", "truffleruby"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
     - run: bundle exec rake rubocop
 
@@ -32,31 +32,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "jruby-9.4", "truffleruby", "head", "jruby-head", "truffleruby-head"]
-
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "jruby-9.4", "truffleruby"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby-version}}
         bundler-cache: true
-        bundler: 2.3.26 # https://github.com/rubygems/rubygems/issues/6435
-    - run: bundle exec rake test
-
-  test-platform:
-    needs: ["rubocop"]
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ["windows-latest", "macos-latest"]
-
-    runs-on: ${{matrix.platform}}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: "3.2"
-        bundler-cache: true
-        bundler: latest
     - run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "head"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,0 +1,25 @@
+name: "ci"
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 5" # At 08:00 on Friday # https://crontab.guru/#0_8_*_*_5
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+    paths:
+      - .github/workflows/upstream.yml # this file
+
+jobs:
+  skeleton:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "Hello, World!"

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["head", "jruby-head", "truffleruby-head"]
+        ruby-version: ["head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
-        with: { ruby-version: "3.3" }
+        with: { ruby-version: "3.4" }
       - run: |
           bundle add ${{matrix.name}} --git="${{matrix.git}}"
           bundle show

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,4 +1,4 @@
-name: "ci"
+name: "upstream"
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
@@ -19,7 +19,33 @@ on:
       - .github/workflows/upstream.yml # this file
 
 jobs:
-  skeleton:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ["head", "jruby-head", "truffleruby-head"]
     runs-on: ubuntu-latest
     steps:
-    - run: echo "Hello, World!"
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{matrix.ruby-version}}
+          bundler-cache: true
+      - run: bundle exec rake test
+
+  upstream:
+    name: "upstream (${{matrix.name}})"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: "nokogiri", git: "https://github.com/sparklemotion/nokogiri" }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with: { ruby-version: "3.3" }
+      - run: |
+          bundle add ${{matrix.name}} --git="${{matrix.git}}"
+          bundle show
+      - run: bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mechanize CHANGELOG
 
-## next / unreleased
+## 2.12.0 / 2024-07-29
 
 * Introduce experimental support for handling Brotli-compressed responses (CRuby only). (#650) @weshatheleopard
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Mechanize CHANGELOG
 
+## 2.8.4 / 2022-01-17
+
+### Fix
+
+* `Mechanize::CookieJar#load` calls `Psych.safe_load` when using Psych >= 3.1
+
+
 ## 2.8.3 / 2021-11-11
 
 ### Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Mechanize CHANGELOG
 
-## next / unreleased
+## 2.9.1 / 2023-04-17
+
+### Update
 
 * Updated User-Agent strings to represent modern browser versions. (#612) Thank you, @takatea!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ Fixes low-severity CVE-2022-31033, "Authorization header leak on port redirect."
   * Fix element(s)_with(search: selector) methods not working for forms, form fields and frames. (#444)
   * Improve the filename parser for the `Content-Disposition` header. (#496, #517)
   * Accept `Content-Encoding: identity`. (#515)
-  * Mechanize::Page#title no longer picks a title in an embeded SVG/RDF element. (#503)
+  * Mechanize::Page#title no longer picks a title in an embedded SVG/RDF element. (#503)
   * Make Mechanize::Form#has_field? boolean. (#501)
 
 ## 2.7.5
@@ -415,8 +415,8 @@ Fixes low-severity CVE-2022-31033, "Authorization header leak on port redirect."
   * When given multiple HTTP authentication options mechanize now picks the
     strongest method.
   * Improvements to HTTP authorization:
-    * mechanize raises Mechanize::UnathorizedError for 401 responses which is
-      a sublcass of Mechanize::ResponseCodeError.
+    * mechanize raises Mechanize::UnauthorizedError for 401 responses which is
+      a subclass of Mechanize::ResponseCodeError.
     * Added support for NTLM authentication, but this has not been tested.
   * Mechanize::Cookie.new accepts attributes in a hash.
   * Mechanize::CookieJar#<<(cookie) (alias: add!) is added.  Issue #139
@@ -507,7 +507,7 @@ Mechanize is now under the MIT license
 
 * New Features
 
-  * Add header reference methods to Mechanize::File so that a reponse
+  * Add header reference methods to Mechanize::File so that a response
     object gets compatible with Net::HTTPResponse.
   * Mechanize#click accepts a regexp or string to click a button/link in the
     current page. It works as expected when not passed a string or regexp.
@@ -732,7 +732,7 @@ Mechanize is now under the MIT license
     http://d.hatena.ne.jp/kitamomonga/20080410/ruby_mechanize_percent_url_bug
   * #21132 Not checking for EOF errors on redirect
   * Fixed a weird gzipping error.
-  * #21233 Smarter multipart boundry. Thanks Todd Willey!
+  * #21233 Smarter multipart boundary. Thanks Todd Willey!
   * #20097 Supporting meta tag cookies.
 
 ## 0.7.6
@@ -841,7 +841,7 @@ Mechanize is now under the MIT license
 * [#9877] Moved last request time.  Thanks Max Stepanov
 * Added WWW::Mechanize::File#save
 * Defaulting file name to URI or Content-Disposition
-* Updating compatability with hpricot
+* Updating compatibility with hpricot
 * Added more unit tests
 
 ## 0.6.7
@@ -853,7 +853,7 @@ Mechanize is now under the MIT license
 
 * Removing hpricot overrides
 * Fixed a bug where alt text can be nil.  Thanks Yannick!
-* Unparseable expiration dates in cookies are now treated as session cookies
+* Unparsable expiration dates in cookies are now treated as session cookies
 * Caching connections
 * Requests now default to keep alive
 * [#9434] Fixed bug where html entities weren't decoded
@@ -919,7 +919,7 @@ Mechanize is now under the MIT license
 * Added a method to Form called "submit".  Now forms can be submitted by
   calling a method on the form.
 * Added a click method to links
-* Added an REXML pluggable parser for backwards compatability.  To use it,
+* Added an REXML pluggable parser for backwards compatibility.  To use it,
   just do this:
    agent.pluggable_parser.html = WWW::Mechanize::REXMLPage
 * Fixed a bug with referrers by adding a page attribute to forms and links.
@@ -1046,7 +1046,7 @@ Mechanize is now under the MIT license
 
 ## 0.4.4
 
-* Fixed error in method signature, basic_authetication is now basic_auth
+* Fixed error in method signature, basic_authentication is now basic_auth
 * Fixed bug with encoding names in file uploads (Big thanks to Alex Young)
 * Added options to the select list
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## next / unreleased
+
+* The `accept-charset` header is no longer sent. In early versions of Mechanize, circa 2007, this was a common header but now no modern browser sends it, and servers are instructed to ignore it. See #646 for an example of a server that is confused by its presence. (#647) @flavorjones
+
+
 ## 2.10.1 / 2024-06-12
 
 * Improve page encoding error recovery on pages with broken encoding when used with libxml2 >= 2.12.0. (#644) @flavorjones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Mechanize CHANGELOG
 
+## next / unreleased
+
+### Requirements
+
+* Mechanize now requires Ruby 2.6 or newer.
+
+
 ## 2.8.5 / 2022-06-09
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Mechanize CHANGELOG
 
+## 2.8.5 / 2022-06-09
+
+### Security
+
+Fixes low-severity CVE-2022-31033, "Authorization header leak on port redirect." See [GHSA-64qm-hrgp-pgr9](https://github.com/sparklemotion/mechanize/security/advisories/GHSA-64qm-hrgp-pgr9) for more details.
+
+
 ## 2.8.4 / 2022-01-17
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## 2.10.0 / 2024-01-22
+
+* Add `nkf` and `base64` as explicit dependencies, since they are being unbundled in Ruby 3.4. (#634) @flavorjones
+
+
 ## 2.9.2 / 2024-01-15
 
 * Correct spelling errors in documentation. (#631) @p-linnane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next / unreleased
 
 * Quash frozen string warnings in Ruby 3.4. (#661) @simpl1g
+* Quash URI::Parser warnings in Ruby 3.4. (#662) @flavorjones
 
 
 ## 2.12.2 / 2023-10-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## 2.10.1 / 2024-06-12
+
+* Improve page encoding error recovery on pages with broken encoding when used with libxml2 >= 2.12.0. (#644) @flavorjones
+
+
 ## 2.10.0 / 2024-01-22
 
 * Add `nkf` and `base64` as explicit dependencies, since they are being unbundled in Ruby 3.4. (#634) @flavorjones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Mechanize CHANGELOG
 
+## 2.9.2 / 2024-01-15
+
+* Correct spelling errors in documentation. (#631) @p-linnane
+* Updated User-Agent strings to represent modern browser versions. (#632) @takatea
+
+
 ## 2.9.1 / 2023-04-17
 
 ### Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## next / unreleased
+
+* Quash frozen string warnings in Ruby 3.4. (#661) @simpl1g
+
+
 ## 2.12.2 / 2023-10-02
 
 * Quash warnings from `Mime::Type.new` in `mime-types` v3.6.0. (#655) @avk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Mechanize CHANGELOG
 
+## 2.8.3 / 2021-11-11
+
+### Update
+
+* Update the "Linux Firefox" user agent string to rev94 (#587) Thank you, @ncs1!
+
+
 ## 2.8.2 / 2021-08-06
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## next / unreleased
+
+* Introduce experimental support for handling Brotli-compressed responses (CRuby only). (#650) @weshatheleopard
+
+
 ## 2.11.0 / 2024-07-18
 
 * The `accept-charset` header is no longer sent. In early versions of Mechanize, circa 2007, this was a common header but now no modern browser sends it, and servers are instructed to ignore it. See #646 for an example of a server that is confused by its presence. (#647) @flavorjones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## 2.12.1 / 2024-08-21
+
+* Introduce experimental support for handling Zstd-compressed responses (CRuby only). (#652) @adrianodennanni
+
+
 ## 2.12.0 / 2024-07-29
 
 * Introduce experimental support for handling Brotli-compressed responses (CRuby only). (#650) @weshatheleopard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mechanize CHANGELOG
 
-## next / unreleased
+## 2.13.0 / 2025-01-02
 
 * Quash frozen string warnings in Ruby 3.4. (#661) @simpl1g
 * Quash URI::Parser warnings in Ruby 3.4. (#662) @flavorjones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## next / unreleased
+
+* `Mechanize` exposes a `write_timeout` attribute, which is set on the connection if it's supported (e.g., Net::HTTP::Persistent.write_timeout). (#586) @maurycy
+
+
 ## 2.13.0 / 2025-01-02
 
 * Quash frozen string warnings in Ruby 3.4. (#661) @simpl1g

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## next / unreleased
+
+* Updated User-Agent strings to represent modern browser versions. (#612) Thank you, @takatea!
+
+
 ## 2.9.0 / 2023-04-07
 
 ### Requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## 2.12.2 / 2023-10-02
+
+* Quash warnings from `Mime::Type.new` in `mime-types` v3.6.0. (#655) @avk
+
+
 ## 2.12.1 / 2024-08-21
 
 * Introduce experimental support for handling Zstd-compressed responses (CRuby only). (#652) @adrianodennanni

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Mechanize now requires Ruby 2.6 or newer.
 
 
+### Improvement
+
+* Mechanize can now parse frozen strings. (#610)
+
+
 ## 2.8.5 / 2022-06-09
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mechanize CHANGELOG
 
-## next / unreleased
+## 2.9.0 / 2023-04-07
 
 ### Requirements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mechanize CHANGELOG
 
-## next / unreleased
+## 2.11.0 / 2024-07-18
 
 * The `accept-charset` header is no longer sent. In early versions of Mechanize, circa 2007, this was a common header but now no modern browser sends it, and servers are instructed to ignore it. See #646 for an example of a server that is confused by its presence. (#647) @flavorjones
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "minitest", "~> 5.14"
+gem "rake", "~> 13.0"
+gem "rdoc", "~> 6.3"
+gem "rubocop", "~> 1.12"
+gem "brotli", ">= 0.5" unless RUBY_PLATFORM == "java"

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,7 @@ gem "minitest", "~> 5.14"
 gem "rake", "~> 13.0"
 gem "rdoc", "~> 6.3"
 gem "rubocop", "~> 1.12"
-gem "brotli", ">= 0.5" unless RUBY_PLATFORM == "java"
+unless RUBY_PLATFORM == 'java'
+  gem 'brotli', '>= 0.5'
+  gem 'zstd-ruby', '~> 1.5'
+end

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * https://www.rubydoc.info/gems/mechanize/
 * https://github.com/sparklemotion/mechanize
 
-[![Test suite](https://github.com/sparklemotion/mechanize/actions/workflows/ci-test.yml/badge.svg)](https://github.com/sparklemotion/mechanize/actions/workflows/ci-test.yml)
+[![Test suite](https://github.com/sparklemotion/mechanize/actions/workflows/ci.yml/badge.svg)](https://github.com/sparklemotion/mechanize/actions/workflows/ci.yml)
 
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Mechanize library is used for automating interaction with websites. Mechaniz
 
 ## Dependencies
 
-* Ruby >= 2.5
+* Ruby >= 2.6
 * Gems:
   * `addressable`
   * `domain_name`

--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ namespace "rubocop" do
 
   desc "Run rubocop string literals check"
   task :frozen_string_literals do
-    sh "rubocop lib --auto-correct-all --only Style/FrozenStringLiteralComment"
+    sh "rubocop lib test --auto-correct-all --only Style/FrozenStringLiteralComment"
   end
 end
 

--- a/examples/latest_user_agents.rb
+++ b/examples/latest_user_agents.rb
@@ -1,7 +1,22 @@
 require 'mechanize'
+require 'ostruct'
 
+# LatestUAFetcher fetches latest user agents from `WhatIsMyBrowser.com`.
+# It can use to update `Mechanize::AGENT_ALIASES`.
 class LatestUAFetcher
   attr_reader :user_agents
+
+  USER_AGENT_TYPES = OpenStruct.new(
+    linux_firefox: "Linux Firefox",
+    mac_firefox: "Mac Firefox",
+    mac_safari: "Mac Safari",
+    windows_chrome: "Windows Chrome",
+    windows_edge: "Windows Edge",
+    windows_firefox: "Windows Firefox",
+    android: "Android",
+    iphone: "iPhone",
+    ipad: "iPad",
+  )
 
   BASE_URL = 'https://www.whatismybrowser.com/guides/the-latest-user-agent'
 
@@ -11,36 +26,37 @@ class LatestUAFetcher
   end
 
   def run
+    return unless user_agents.empty?
+
     sleep_time = 1
 
-    puts 'get chrome UA...'
-    chrome
-    puts "sleeping... (#{sleep_time}s)"
-    sleep 1
+    fetch_user_agents('chrome')
+    fetch_user_agents('firefox')
+    fetch_user_agents('safari')
+    fetch_user_agents('edge')
+  end
 
-    puts 'get firefox UA...'
-    firefox
-    puts "sleeping... (#{sleep_time}s)"
-    sleep 1
-
-    puts 'get safari UA...'
-    safari
-    puts "sleeping... (#{sleep_time}s)"
-    sleep 1
-
-    puts 'get edge UA...'
-    edge
+  def ordered_user_agents
+    USER_AGENT_TYPES.to_h.values.each_with_object({}) do |type, ordered_user_agents|
+      ordered_user_agents[type] = user_agents[type]
+    end
   end
 
   private
+
+  def fetch_user_agents(browser_name, sleep_time = 1)
+    puts "fetch #{browser_name} UA..."
+    send(browser_name)
+    puts "sleeping... (#{sleep_time}s)"
+    sleep sleep_time
+  end
 
   def edge
     page = @agent.get("#{BASE_URL}/edge")
 
     windows_dom = page.css("h2:contains('Latest Edge on Windows User Agents')")
-    @user_agents[:edge] = {
-      windows: windows_dom.css('+ .listing-of-useragents .code').first.text
-    }
+
+    @user_agents[USER_AGENT_TYPES.windows_edge] = windows_dom.css('+ .listing-of-useragents .code').first.text
   end
 
   def firefox
@@ -49,11 +65,9 @@ class LatestUAFetcher
     desktop_dom = page.css("h2:contains('Latest Firefox on Desktop User Agents')")
     table_dom = desktop_dom.css('+ .listing-of-useragents')
 
-    @user_agents[:firefox] = {
-      windows: table_dom.css('td:contains("Windows")').css('+ td .code').text,
-      macOS: table_dom.css('td:contains("Macos")').css('+ td .code').text,
-      linux: table_dom.css('td:contains("Linux")').css("+ td .code:contains('Ubuntu; Linux x86_64')").text
-    }
+    @user_agents[USER_AGENT_TYPES.linux_firefox] = table_dom.css('td:contains("Linux")').css("+ td .code:contains('Ubuntu; Linux x86_64')").text
+    @user_agents[USER_AGENT_TYPES.windows_firefox] = table_dom.css('td:contains("Windows")').css('+ td .code').text
+    @user_agents[USER_AGENT_TYPES.mac_firefox] = table_dom.css('td:contains("Macos")').css('+ td .code').text
   end
 
   def safari
@@ -62,30 +76,25 @@ class LatestUAFetcher
     macos_dom = page.css("h2:contains('Latest Safari on macOS User Agents')")
     ios_dom = page.css("h2:contains('Latest Safari on iOS User Agents')")
 
-    @user_agents[:safari] = {
-      mac_os: macos_dom.css('+ .listing-of-useragents .code').first.text,
-      iphone: ios_dom.css('+ .listing-of-useragents').css("tr:contains('Iphone') .code").text,
-      ipad: ios_dom.css('+ .listing-of-useragents').css("tr:contains('Ipad') .code").text
-    }
+    @user_agents[USER_AGENT_TYPES.mac_safari] = macos_dom.css('+ .listing-of-useragents .code').first.text
+    @user_agents[USER_AGENT_TYPES.iphone] = ios_dom.css('+ .listing-of-useragents').css("tr:contains('Iphone') .code").text
+    @user_agents[USER_AGENT_TYPES.ipad] = ios_dom.css('+ .listing-of-useragents').css("tr:contains('Ipad') .code").text
   end
 
   def chrome
     page = @agent.get("#{BASE_URL}/chrome")
 
     windows_dom = page.css("h2:contains('Latest Chrome on Windows 10 User Agents')")
-    linux_dom = page.css("h2:contains('Latest Chrome on Linux User Agents')")
-    macos_dom = page.css("h2:contains('Latest Chrome on macOS User Agents')")
     android_dom = page.css("h2:contains('Latest Chrome on Android User Agents')")
 
-    @user_agents[:chrome] = {
-      windows: windows_dom.css('+ .listing-of-useragents .code').first.text,
-      linux: linux_dom.css('+ .listing-of-useragents .code').first.text,
-      mac_os: macos_dom.css('+ .listing-of-useragents .code').first.text,
-      android: android_dom.css('+ .listing-of-useragents .code').first.text
-    }
+    @user_agents[USER_AGENT_TYPES.windows_chrome] = windows_dom.css('+ .listing-of-useragents .code').first.text
+    @user_agents[USER_AGENT_TYPES.android] = android_dom.css('+ .listing-of-useragents .code').first.text
   end
 end
 
-agent = LatestUAFetcher.new
-agent.run
-p agent.user_agents
+if $0 == __FILE__
+  agent = LatestUAFetcher.new
+  agent.run
+
+  pp agent.ordered_user_agents
+end

--- a/examples/latest_user_agents.rb
+++ b/examples/latest_user_agents.rb
@@ -1,0 +1,91 @@
+require 'mechanize'
+
+class LatestUAFetcher
+  attr_reader :user_agents
+
+  BASE_URL = 'https://www.whatismybrowser.com/guides/the-latest-user-agent'
+
+  def initialize
+    @agent = Mechanize.new.tap { |a| a.user_agent_alias = 'Mac Firefox' }
+    @user_agents = {}
+  end
+
+  def run
+    sleep_time = 1
+
+    puts 'get chrome UA...'
+    chrome
+    puts "sleeping... (#{sleep_time}s)"
+    sleep 1
+
+    puts 'get firefox UA...'
+    firefox
+    puts "sleeping... (#{sleep_time}s)"
+    sleep 1
+
+    puts 'get safari UA...'
+    safari
+    puts "sleeping... (#{sleep_time}s)"
+    sleep 1
+
+    puts 'get edge UA...'
+    edge
+  end
+
+  private
+
+  def edge
+    page = @agent.get("#{BASE_URL}/edge")
+
+    windows_dom = page.css("h2:contains('Latest Edge on Windows User Agents')")
+    @user_agents[:edge] = {
+      windows: windows_dom.css('+ .listing-of-useragents .code').first.text
+    }
+  end
+
+  def firefox
+    page = @agent.get("#{BASE_URL}/firefox")
+
+    desktop_dom = page.css("h2:contains('Latest Firefox on Desktop User Agents')")
+    table_dom = desktop_dom.css('+ .listing-of-useragents')
+
+    @user_agents[:firefox] = {
+      windows: table_dom.css('td:contains("Windows")').css('+ td .code').text,
+      macOS: table_dom.css('td:contains("Macos")').css('+ td .code').text,
+      linux: table_dom.css('td:contains("Linux")').css("+ td .code:contains('Ubuntu; Linux x86_64')").text
+    }
+  end
+
+  def safari
+    page = @agent.get("#{BASE_URL}/safari")
+
+    macos_dom = page.css("h2:contains('Latest Safari on macOS User Agents')")
+    ios_dom = page.css("h2:contains('Latest Safari on iOS User Agents')")
+
+    @user_agents[:safari] = {
+      mac_os: macos_dom.css('+ .listing-of-useragents .code').first.text,
+      iphone: ios_dom.css('+ .listing-of-useragents').css("tr:contains('Iphone') .code").text,
+      ipad: ios_dom.css('+ .listing-of-useragents').css("tr:contains('Ipad') .code").text
+    }
+  end
+
+  def chrome
+    page = @agent.get("#{BASE_URL}/chrome")
+
+    windows_dom = page.css("h2:contains('Latest Chrome on Windows 10 User Agents')")
+    linux_dom = page.css("h2:contains('Latest Chrome on Linux User Agents')")
+    macos_dom = page.css("h2:contains('Latest Chrome on macOS User Agents')")
+    android_dom = page.css("h2:contains('Latest Chrome on Android User Agents')")
+
+    @user_agents[:chrome] = {
+      windows: windows_dom.css('+ .listing-of-useragents .code').first.text,
+      linux: linux_dom.css('+ .listing-of-useragents .code').first.text,
+      mac_os: macos_dom.css('+ .listing-of-useragents .code').first.text,
+      android: android_dom.css('+ .listing-of-useragents .code').first.text
+    }
+  end
+end
+
+agent = LatestUAFetcher.new
+agent.run
+p agent.user_agents

--- a/examples/wikipedia_links_to_philosophy.rb
+++ b/examples/wikipedia_links_to_philosophy.rb
@@ -58,10 +58,10 @@ class WikipediaLinksToPhilosophy
   # the article.
 
   def follow_first_link
-    puts @title
+    puts "#{@title} (#{@page.uri})"
 
     # > p > a rejects italics
-    links = @page.root.css('.mw-content-ltr > p > a[href^="/wiki/"]')
+    links = @page.root.css('.mw-content-ltr p > a[href^="/wiki/"]')
 
     # reject disambiguation and special pages, images and files
     links = links.reject do |link_node|
@@ -74,10 +74,9 @@ class WikipediaLinksToPhilosophy
 
     link = links.first
 
-    unless link then
-      # disambiguation page? try the first item in the list
-      link =
-        @page.root.css('.mw-content-ltr > ul > li > a[href^="/wiki/"]').first
+    if link.nil?
+      puts "Could not parse #{@page.uri}"
+      exit 1
     end
 
     # convert a Nokogiri HTML element back to a mechanize link

--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -952,6 +952,21 @@ Use of #auth and #basic_auth are deprecated due to a security vulnerability.
   end
 
   ##
+  # Length of time to wait for data to be sent to the server
+
+  def write_timeout
+    @agent.write_timeout
+  end
+
+  ##
+  # Sets the timeout for each chunk of data to be sent to the server to
+  # +write_timeout+.  A single request may write many chunks of data.
+
+  def write_timeout= write_timeout
+    @agent.write_timeout = write_timeout
+  end
+
+  ##
   # Controls how mechanize deals with redirects.  The following values are
   # allowed:
   #

--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -105,6 +105,7 @@ class Mechanize
   #
   # Windows User-Agent aliases:
   #
+  # * "Windows Chrome"
   # * "Windows Edge"
   # * "Windows Firefox"
   # * "Windows IE 6"
@@ -127,21 +128,20 @@ class Mechanize
   #   agent.user_agent_alias = 'Mac Safari'
   #
   AGENT_ALIASES = {
-    # TODO: use output from examples/latest_user_agents.rb as the underling data structure
     'Mechanize' => "Mechanize/#{VERSION} Ruby/#{ruby_version} (http://github.com/sparklemotion/mechanize/)",
 
-    'Linux Firefox' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:112.0) Gecko/20100101 Firefox/112.0',
+    'Linux Firefox' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0',
     'Linux Konqueror' => 'Mozilla/5.0 (compatible; Konqueror/3; Linux)',
     'Linux Mozilla' => 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.4) Gecko/20030624',
 
-    'Mac Firefox' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 13.3; rv:112.0) Gecko/20100101 Firefox/112.0',
+    'Mac Firefox' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14.2; rv:109.0) Gecko/20100101 Firefox/121.0',
     'Mac Mozilla' => 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.4a) Gecko/20030401',
     'Mac Safari 4' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_2; de-at) AppleWebKit/531.21.8 (KHTML, like Gecko) Version/4.0.4 Safari/531.21.10',
-    'Mac Safari' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_3_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15',
+    'Mac Safari' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
 
-    'Windows Chrome' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',
-    'Windows Edge' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 Edg/112.0.1722.46',
-    'Windows Firefox' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:112.0) Gecko/20100101 Firefox/112.0',
+    'Windows Chrome' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    'Windows Edge' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.2210.133',
+    'Windows Firefox' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0',
     'Windows IE 6' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
     'Windows IE 7' => 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727)',
     'Windows IE 8' => 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727)',
@@ -150,9 +150,9 @@ class Mechanize
     'Windows IE 11' => 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko',
     'Windows Mozilla' => 'Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4b) Gecko/20030516 Mozilla Firebird/0.6',
 
-    'Android' => 'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.48 Mobile Safari/537.36',
-    'iPad' => 'Mozilla/5.0 (iPad; CPU OS 16_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Mobile/15E148 Safari/604.1',
-    'iPhone' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Mobile/15E148 Safari/604.1',
+    'Android' => 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.210 Mobile Safari/537.36',
+    'iPad' => 'Mozilla/5.0 (iPad; CPU OS 17_2_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
+    'iPhone' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
   }
 
   AGENT_ALIASES.default_proc = proc { |hash, key|

--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -717,10 +717,10 @@ class Mechanize
   # authentication.
 
   def auth user, password, domain = nil
-    caller.first =~ /(.*?):(\d+).*?$/
+    c = caller_locations(1,1).first
 
     warn <<-WARNING
-At #{$1} line #{$2}
+At #{c.absolute_path} line #{c.lineno}
 
 Use of #auth and #basic_auth are deprecated due to a security vulnerability.
 

--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -200,7 +200,7 @@ class Mechanize
   #
   # If you need segregated SSL connections give each agent a unique
   # name.  Otherwise the connections will be shared.  This is
-  # particularly important if you are using certifcates.
+  # particularly important if you are using certificates.
   #
   #    agent_1 = Mechanize.new 'conn1'
   #    agent_2 = Mechanize.new 'conn2'
@@ -956,7 +956,7 @@ Use of #auth and #basic_auth are deprecated due to a security vulnerability.
   # allowed:
   #
   # :all, true:: All 3xx redirects are followed (default)
-  # :permanent:: Only 301 Moved Permanantly redirects are followed
+  # :permanent:: Only 301 Moved Permanently redirects are followed
   # false:: No redirects are followed
 
   def redirect_ok

--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -115,7 +115,7 @@ class Mechanize
 
   AGENT_ALIASES = {
     'Mechanize' => "Mechanize/#{VERSION} Ruby/#{ruby_version} (http://github.com/sparklemotion/mechanize/)",
-    'Linux Firefox' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:43.0) Gecko/20100101 Firefox/43.0',
+    'Linux Firefox' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0',
     'Linux Konqueror' => 'Mozilla/5.0 (compatible; Konqueror/3; Linux)',
     'Linux Mozilla' => 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.4) Gecko/20030624',
     'Mac Firefox' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:43.0) Gecko/20100101 Firefox/43.0',

--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -2,7 +2,6 @@
 require 'mechanize/version'
 require 'fileutils'
 require 'forwardable'
-require 'mutex_m'
 require 'net/http/digest_auth'
 require 'net/http/persistent'
 require 'nokogiri'

--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -87,54 +87,73 @@ class Mechanize
   # description in parenthesis is for informative purposes and is not part of
   # the alias name.
   #
-  # * Linux Firefox (43.0 on Ubuntu Linux)
-  # * Linux Konqueror (3)
-  # * Linux Mozilla
-  # * Mac Firefox (43.0)
-  # * Mac Mozilla
-  # * Mac Safari (9.0 on OS X 10.11.2)
-  # * Mac Safari 4
-  # * Mechanize (default)
-  # * Windows IE 6
-  # * Windows IE 7
-  # * Windows IE 8
-  # * Windows IE 9
-  # * Windows IE 10 (Windows 8 64bit)
-  # * Windows IE 11 (Windows 8.1 64bit)
-  # * Windows Edge
-  # * Windows Mozilla
-  # * Windows Firefox (43.0)
-  # * iPhone (iOS 9.1)
-  # * iPad (iOS 9.1)
-  # * Android (5.1.1)
+  # The default User-Agent alias:
+  #
+  # * "Mechanize"
+  #
+  # Linux User-Agent aliases:
+  #
+  # * "Linux Firefox"
+  # * "Linux Konqueror"
+  # * "Linux Mozilla"
+  #
+  # Mac User-Agent aliases:
+  #
+  # * "Mac Firefox"
+  # * "Mac Mozilla"
+  # * "Mac Safari 4"
+  # * "Mac Safari"
+  #
+  # Windows User-Agent aliases:
+  #
+  # * "Windows Edge"
+  # * "Windows Firefox"
+  # * "Windows IE 6"
+  # * "Windows IE 7"
+  # * "Windows IE 8"
+  # * "Windows IE 9"
+  # * "Windows IE 10"
+  # * "Windows IE 11"
+  # * "Windows Mozilla"
+  #
+  # Mobile User-Agent aliases:
+  #
+  # * "Android"
+  # * "iPad"
+  # * "iPhone"
   #
   # Example:
   #
   #   agent = Mechanize.new
   #   agent.user_agent_alias = 'Mac Safari'
-
+  #
   AGENT_ALIASES = {
+    # TODO: use output from examples/latest_user_agents.rb as the underling data structure
     'Mechanize' => "Mechanize/#{VERSION} Ruby/#{ruby_version} (http://github.com/sparklemotion/mechanize/)",
-    'Linux Firefox' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0',
+
+    'Linux Firefox' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:112.0) Gecko/20100101 Firefox/112.0',
     'Linux Konqueror' => 'Mozilla/5.0 (compatible; Konqueror/3; Linux)',
     'Linux Mozilla' => 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.4) Gecko/20030624',
-    'Mac Firefox' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:43.0) Gecko/20100101 Firefox/43.0',
+
+    'Mac Firefox' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 13.3; rv:112.0) Gecko/20100101 Firefox/112.0',
     'Mac Mozilla' => 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.4a) Gecko/20030401',
     'Mac Safari 4' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_2; de-at) AppleWebKit/531.21.8 (KHTML, like Gecko) Version/4.0.4 Safari/531.21.10',
-    'Mac Safari' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9',
-    'Windows Chrome' => 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.125 Safari/537.36',
+    'Mac Safari' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_3_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15',
+
+    'Windows Chrome' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',
+    'Windows Edge' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 Edg/112.0.1722.46',
+    'Windows Firefox' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:112.0) Gecko/20100101 Firefox/112.0',
     'Windows IE 6' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
     'Windows IE 7' => 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727)',
     'Windows IE 8' => 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727)',
     'Windows IE 9' => 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)',
     'Windows IE 10' => 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)',
     'Windows IE 11' => 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko',
-    'Windows Edge' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586',
     'Windows Mozilla' => 'Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4b) Gecko/20030516 Mozilla Firebird/0.6',
-    'Windows Firefox' => 'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:43.0) Gecko/20100101 Firefox/43.0',
-    'iPhone' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B5110e Safari/601.1',
-    'iPad' => 'Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
-    'Android' => 'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 7 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.76 Safari/537.36',
+
+    'Android' => 'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.48 Mobile Safari/537.36',
+    'iPad' => 'Mozilla/5.0 (iPad; CPU OS 16_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Mobile/15E148 Safari/604.1',
+    'iPhone' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Mobile/15E148 Safari/604.1',
   }
 
   AGENT_ALIASES.default_proc = proc { |hash, key|

--- a/lib/mechanize/cookie.rb
+++ b/lib/mechanize/cookie.rb
@@ -7,7 +7,7 @@ class Mechanize
   module CookieDeprecated
     def __deprecated__(to = nil)
       $VERBOSE or return
-      method = caller[0][/([^`]+)(?='$)/]
+      method = caller_locations(1,1).first.base_label
       to ||= method
       case self
       when Class
@@ -21,7 +21,7 @@ class Mechanize
         this = '%s#%s' % [klass, method]
         that = 'HTTP::%s#%s' % [lname, to]
       end
-      warn '%s: The call of %s needs to be fixed to follow the new API (%s).' % [caller[1], this, that]
+      warn '%s: The call of %s needs to be fixed to follow the new API (%s).' % [caller_locations(2,1).first, this, that]
     end
     private :__deprecated__
   end

--- a/lib/mechanize/cookie_jar.rb
+++ b/lib/mechanize/cookie_jar.rb
@@ -149,7 +149,7 @@ class Mechanize
       return super(input, opthash) if opthash[:format] != :yaml
 
       begin
-        data = YAML.load(input) # rubocop:disable Security/YAMLLoad
+        data = load_yaml(input)
       rescue ArgumentError
         @logger.warn "unloadable YAML cookie data discarded" if @logger
         return self
@@ -172,6 +172,18 @@ class Mechanize
       else
         @logger.warn "incompatible YAML cookie data discarded" if @logger
         return self
+      end
+    end
+
+    private
+
+    if YAML.name == "Psych" && Gem::Requirement.new(">= 3.1").satisfied_by?(Gem::Version.new(Psych::VERSION))
+      def load_yaml(yaml)
+        YAML.safe_load(yaml, aliases: true, permitted_classes: ["Mechanize::Cookie", "Time"])
+      end
+    else
+      def load_yaml(yaml)
+        YAML.load(yaml) # rubocop:disable Security/YAMLLoad
       end
     end
   end

--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -482,7 +482,7 @@ class Mechanize::Form
   #   form.file_upload_with(:file_name => /picture/).value = 'foo'
 
   ##
-  # :mehtod: file_upload_with!(criteria)
+  # :method: file_upload_with!(criteria)
   #
   # Same as +file_upload_with+ but raises an ElementNotFoundError if no button
   # matches +criteria+
@@ -506,7 +506,7 @@ class Mechanize::Form
   #   form.radiobutton_with(:name => /woo/).check
 
   ##
-  # :mehtod: radiobutton_with!(criteria)
+  # :method: radiobutton_with!(criteria)
   #
   # Same as +radiobutton_with+ but raises an ElementNotFoundError if no button
   # matches +criteria+
@@ -530,7 +530,7 @@ class Mechanize::Form
   #   form.checkbox_with(:name => /woo/).check
 
   ##
-  # :mehtod: checkbox_with!(criteria)
+  # :method: checkbox_with!(criteria)
   #
   # Same as +checkbox_with+ but raises an ElementNotFoundError if no button
   # matches +criteria+

--- a/lib/mechanize/form.rb
+++ b/lib/mechanize/form.rb
@@ -256,7 +256,7 @@ class Mechanize::Form
 
   # Treat form fields like accessors.
   def method_missing(meth, *args)
-    (method = meth.to_s).chomp!('=')
+    method = meth.to_s.chomp('=')
 
     if field(method)
       return field(method).value if args.empty?

--- a/lib/mechanize/form/multi_select_list.rb
+++ b/lib/mechanize/form/multi_select_list.rb
@@ -36,7 +36,7 @@ class Mechanize::Form::MultiSelectList < Mechanize::Form::Field
   #   select_list.option_with(:value => '1').value = 'foo'
 
   ##
-  # :mehtod: option_with!(criteria)
+  # :method: option_with!(criteria)
   #
   # Same as +option_with+ but raises an ElementNotFoundError if no button
   # matches +criteria+

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -581,7 +581,6 @@ class Mechanize::HTTP::Agent
   end
 
   def request_language_charset request
-    request['accept-charset']  = 'ISO-8859-1,utf-8;q=0.7,*;q=0.7'
     request['accept-language'] = 'en-us,en;q=0.5'
   end
 

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -106,6 +106,9 @@ class Mechanize::HTTP::Agent
   # Length of time to attempt to read data from the server
   attr_accessor  :read_timeout
 
+  # Length of time to attempt to write data to the server
+  attr_accessor  :write_timeout
+
   # :section:
 
   # The cookies for this agent
@@ -161,6 +164,7 @@ class Mechanize::HTTP::Agent
     @robots_mutex             = Mutex.new
     @user_agent               = nil
     @webrobots                = nil
+    @write_timeout            = nil
 
     # HTTP Authentication
     @auth_store           = Mechanize::HTTP::AuthStore.new
@@ -273,6 +277,9 @@ class Mechanize::HTTP::Agent
     end
     if @read_timeout && connection.respond_to?(:read_timeout=)
       connection.read_timeout = @read_timeout
+    end
+    if @write_timeout && connection.respond_to?(:write_timeout=)
+      connection.write_timeout = @write_timeout
     end
 
     request_log request

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -66,7 +66,7 @@ class Mechanize::HTTP::Agent
   # allowed:
   #
   # :all, true:: All 3xx redirects are followed (default)
-  # :permanent:: Only 301 Moved Permanantly redirects are followed
+  # :permanent:: Only 301 Moved Permanently redirects are followed
   # false:: No redirects are followed
   attr_accessor :redirect_ok
 

--- a/lib/mechanize/http/content_disposition_parser.rb
+++ b/lib/mechanize/http/content_disposition_parser.rb
@@ -81,7 +81,7 @@ class Mechanize::HTTP::ContentDispositionParser
   end
 
   ##
-  # Extracts disposition-parm and returns a Hash.
+  # Extracts disposition-param and returns a Hash.
 
   def parse_parameters
     parameters = {}
@@ -200,4 +200,3 @@ class Mechanize::HTTP::ContentDispositionParser
   end
 
 end
-

--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -95,7 +95,7 @@ class Mechanize::Page < Mechanize::File
   end
 
   # Return whether parser result has errors related to encoding or not.
-  # false indicates just parser has no encoding errors, not encoding is vaild.
+  # false indicates just parser has no encoding errors, not encoding is valid.
   def encoding_error?(parser=nil)
     parser = self.parser unless parser
     return false if parser.errors.empty?

--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -101,6 +101,7 @@ class Mechanize::Page < Mechanize::File
     return false if parser.errors.empty?
     parser.errors.any? do |error|
       error.message.scrub =~ /(indicate\ encoding)|
+                              (Invalid\ bytes)|
                               (Invalid\ char)|
                               (input\ conversion\ failed)/x
     end

--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -41,10 +41,6 @@ class Mechanize::Page < Mechanize::File
     @encodings.concat self.class.response_header_charset(response)
 
     if body
-      # Force the encoding to be 8BIT so we can perform regular expressions.
-      # We'll set it to the detected encoding later
-      body.force_encoding(Encoding::ASCII_8BIT)
-
       @encodings.concat self.class.meta_charset body
 
       meta_content_type = self.class.meta_content_type body

--- a/lib/mechanize/pluggable_parsers.rb
+++ b/lib/mechanize/pluggable_parsers.rb
@@ -104,7 +104,7 @@ class Mechanize::PluggableParser
 
     return parser if parser
 
-    mime_type = MIME::Type.new content_type
+    mime_type = MIME::Type.new "content-type" => content_type
 
     parser = @parsers[mime_type.to_s] ||
              @parsers[mime_type.simplified] ||

--- a/lib/mechanize/test_case.rb
+++ b/lib/mechanize/test_case.rb
@@ -15,11 +15,6 @@ end
 
 require 'minitest/autorun'
 
-begin
-  require 'minitest/pride'
-rescue LoadError
-end
-
 ##
 # A generic test case for testing mechanize.  Using a subclass of
 # Mechanize::TestCase for your tests will create an isolated mechanize

--- a/lib/mechanize/util.rb
+++ b/lib/mechanize/util.rb
@@ -134,29 +134,27 @@ class Mechanize::Util
   end
 
   def self.uri_escape str, unsafe = nil
-    @parser ||= begin
-                  URI::Parser.new
-                rescue NameError
-                  URI
-                end
-
-    if URI == @parser then
+    if URI == parser then
       unsafe ||= URI::UNSAFE
     else
-      unsafe ||= @parser.regexp[:UNSAFE]
+      unsafe ||= parser.regexp[:UNSAFE]
     end
 
-    @parser.escape str, unsafe
+    parser.escape str, unsafe
   end
 
   def self.uri_unescape str
-    @parser ||= begin
-                  URI::Parser.new
-                rescue NameError
-                  URI
-                end
-
-    @parser.unescape str
+    parser.unescape str
   end
 
+  def self.parser
+    @parser ||=
+      if defined?(URI::RFC2396_PARSER)
+        URI::RFC2396_PARSER
+      elsif defined?(URI::Parser)
+        URI::Parser.new
+      else
+        URI
+      end
+  end
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.9.2"
+  VERSION = "2.10.0"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.11.0"
+  VERSION = "2.12.0"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.8.2"
+  VERSION = "2.8.3"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.10.0"
+  VERSION = "2.10.1"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.8.4"
+  VERSION = "2.8.5"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.12.1"
+  VERSION = "2.12.2"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.12.2"
+  VERSION = "2.13.0"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.10.1"
+  VERSION = "2.11.0"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.8.5"
+  VERSION = "2.9.0"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.12.0"
+  VERSION = "2.12.1"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.9.0"
+  VERSION = "2.9.1"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.9.1"
+  VERSION = "2.9.2"
 end

--- a/lib/mechanize/version.rb
+++ b/lib/mechanize/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Mechanize
-  VERSION = "2.8.3"
+  VERSION = "2.8.4"
 end

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -71,9 +71,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("rubyntlm", ">= 0.6.3", "~> 0.6")
   spec.add_runtime_dependency("base64") # removed from bundled gems in 3.4, and needed by rubyntlm (which doesn't declare this dependency)
   spec.add_runtime_dependency("nkf") # removed from bundled gems in 3.4
-
-  spec.add_development_dependency("minitest", "~> 5.14")
-  spec.add_development_dependency("rake", "~> 13.0")
-  spec.add_development_dependency("rdoc", "~> 6.3")
-  spec.add_development_dependency("rubocop", "~> 1.12")
 end

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files += Dir['*.rdoc', '*.md']
   spec.rdoc_options = ["--main", "README.md"]
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_runtime_dependency("addressable", "~> 2.8")
   spec.add_runtime_dependency("domain_name", ">= 0.5.20190701", "~> 0.5")

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("addressable", "~> 2.8")
   spec.add_runtime_dependency("domain_name", ">= 0.5.20190701", "~> 0.5")
   spec.add_runtime_dependency("http-cookie", ">= 1.0.3", "~> 1.0")
-  spec.add_runtime_dependency("mime-types", "~> 3.0")
+  spec.add_runtime_dependency("mime-types", "~> 3.3")
   spec.add_runtime_dependency("net-http-digest_auth", ">= 1.4.1", "~> 1.4")
 
   # careful! some folks are relying on older versions of net-http-persistent

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -65,9 +65,12 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("net-http-persistent", ">= 2.5.2", "< 5.0.dev")
 
   spec.add_runtime_dependency("nokogiri", ">= 1.11.2", "~> 1.11")
-  spec.add_runtime_dependency("rubyntlm", ">= 0.6.3", "~> 0.6")
   spec.add_runtime_dependency("webrick", "~> 1.7")
   spec.add_runtime_dependency("webrobots", "~> 0.1.2")
+
+  spec.add_runtime_dependency("rubyntlm", ">= 0.6.3", "~> 0.6")
+  spec.add_runtime_dependency("base64") # removed from bundled gems in 3.4, and needed by rubyntlm (which doesn't declare this dependency)
+  spec.add_runtime_dependency("nkf") # removed from bundled gems in 3.4
 
   spec.add_development_dependency("minitest", "~> 5.14")
   spec.add_development_dependency("rake", "~> 13.0")

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -1020,6 +1020,12 @@ but not <a href="/" rel="me nofollow">this</a>!
     assert_equal 5, @mech.read_timeout
   end
 
+  def test_write_timeout_equals
+    @mech.write_timeout = 7
+
+    assert_equal 7, @mech.write_timeout
+  end
+
   def test_timeouts_for_file_connection
     uri = URI.parse "file://#{File.expand_path __FILE__}"
     @mech.read_timeout = 5

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 
@@ -965,7 +966,7 @@ but not <a href="/" rel="me nofollow">this</a>!
     })
 
     assert_match(
-      "Content-Disposition: form-data; name=\"userfile1\"; filename=\"#{name}\"".force_encoding(Encoding::ASCII_8BIT),
+      "Content-Disposition: form-data; name=\"userfile1\"; filename=\"#{name}\"".dup.force_encoding(Encoding::ASCII_8BIT),
       page.body
     )
     assert_match("Content-Type: application/zip", page.body)

--- a/test/test_mechanize_cookie.rb
+++ b/test/test_mechanize_cookie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 module Enumerable
@@ -301,7 +302,7 @@ class TestMechanizeCookie < Mechanize::TestCase
     expires = Time.parse('Sun, 27-Sep-2037 00:00:00 GMT')
 
     cookie_params.keys.combine.each do |c|
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -336,7 +337,7 @@ class TestMechanizeCookie < Mechanize::TestCase
     expires = Time.parse('Sun, 27-Sep-2037 00:00:00 GMT')
 
     cookie_params.keys.combine.each do |c|
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -373,7 +374,7 @@ class TestMechanizeCookie < Mechanize::TestCase
 
     cookie_params.keys.combine.each do |c|
       next if c.find { |k| k == 'path' }
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -410,7 +411,7 @@ class TestMechanizeCookie < Mechanize::TestCase
 
     cookie_params.keys.combine.each do |c|
       next unless c.find { |k| k == 'secure' }
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -446,7 +447,7 @@ class TestMechanizeCookie < Mechanize::TestCase
     expires = Time.parse('Sun, 27-Sep-2037 00:00:00 GMT')
 
     cookie_params.keys.combine.each do |c|
-      cookie_text = "#{cookie_value};"
+      cookie_text = +"#{cookie_value};"
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -530,7 +531,7 @@ class TestMechanizeCookie < Mechanize::TestCase
     expires = Time.parse('Sun, 27-Sep-2037 00:00:00 GMT')
 
     cookie_params.keys.combine.each do |c|
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"

--- a/test/test_mechanize_cookie.rb
+++ b/test/test_mechanize_cookie.rb
@@ -502,12 +502,23 @@ class TestMechanizeCookie < Mechanize::TestCase
     cookie.domain = 'Dom.example.com'
     assert 'dom.example.com', cookie.domain
 
-    cookie.domain = Object.new.tap { |o|
+    new_domain = Object.new.tap { |o|
       def o.to_str
         'Example.com'
       end
     }
+    cookie.domain = new_domain
     assert 'example.com', cookie.domain
+
+    new_domain = Object.new.tap { |o|
+      def o.to_str
+        'Example2.com'
+      end
+    }
+    assert_output nil, /The call of Mechanize::Cookie#set_domain/ do
+      cookie.set_domain(new_domain)
+    end
+    assert 'example2.com', cookie.domain
   end
 
   def test_cookie_httponly

--- a/test/test_mechanize_cookie_jar.rb
+++ b/test/test_mechanize_cookie_jar.rb
@@ -540,7 +540,7 @@ class TestMechanizeCookieJar < Mechanize::TestCase
 
     @jar.add url, Mechanize::Cookie.new(cookie_values)
 
-    # HACK no asertion
+    # HACK no assertion
   end
 
   def test_ssl_cookies

--- a/test/test_mechanize_cookie_jar.rb
+++ b/test/test_mechanize_cookie_jar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 require 'fileutils'
 

--- a/test/test_mechanize_directory_saver.rb
+++ b/test/test_mechanize_directory_saver.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeDirectorySaver < Mechanize::TestCase

--- a/test/test_mechanize_download.rb
+++ b/test/test_mechanize_download.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeDownload < Mechanize::TestCase

--- a/test/test_mechanize_element_not_found_error.rb
+++ b/test/test_mechanize_element_not_found_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeRedirectLimitReachedError < Mechanize::TestCase

--- a/test/test_mechanize_file.rb
+++ b/test/test_mechanize_file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFile < Mechanize::TestCase

--- a/test/test_mechanize_file_connection.rb
+++ b/test/test_mechanize_file_connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFileConnection < Mechanize::TestCase
@@ -7,7 +8,7 @@ class TestMechanizeFileConnection < Mechanize::TestCase
     uri = URI.parse "file://#{file_path}"
     conn = Mechanize::FileConnection.new
 
-    body = ''
+    body = +''
 
     conn.request uri, nil do |response|
       assert_equal(file_path, response.file_path)

--- a/test/test_mechanize_file_request.rb
+++ b/test/test_mechanize_file_request.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFileRequest < Mechanize::TestCase

--- a/test/test_mechanize_file_response.rb
+++ b/test/test_mechanize_file_response.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFileResponse < Mechanize::TestCase

--- a/test/test_mechanize_file_saver.rb
+++ b/test/test_mechanize_file_saver.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFileSaver < Mechanize::TestCase

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeForm < Mechanize::TestCase

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -357,7 +357,7 @@ class TestMechanizeForm < Mechanize::TestCase
     assert_equal 'ticky=1&ticky=0', submitted.parser.at('#query').text
   end
 
-  def test_submit_takes_arbirary_headers
+  def test_submit_takes_arbitrary_headers
     page = @mech.get('http://localhost:2000/form_no_action.html')
     assert form = page.forms.first
     form.action = '/http_headers'

--- a/test/test_mechanize_form_check_box.rb
+++ b/test/test_mechanize_form_check_box.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormCheckBox < Mechanize::TestCase

--- a/test/test_mechanize_form_encoding.rb
+++ b/test/test_mechanize_form_encoding.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormEncoding < Mechanize::TestCase
@@ -8,7 +9,7 @@ class TestMechanizeFormEncoding < Mechanize::TestCase
 
   INPUTTED_VALUE = "テスト" # "test" in Japanese UTF-8 encoding
   CONTENT_ENCODING = 'Shift_JIS' # one of Japanese encoding
-  encoded_value = "\x83\x65\x83\x58\x83\x67".force_encoding(::Encoding::SHIFT_JIS) # "test" in Japanese Shift_JIS encoding
+  encoded_value = "\x83\x65\x83\x58\x83\x67".dup.force_encoding(::Encoding::SHIFT_JIS) # "test" in Japanese Shift_JIS encoding
   EXPECTED_QUERY = "first_name=#{CGI.escape(encoded_value)}&first_name=&gender=&green%5Beggs%5D="
 
   ENCODING_ERRORS = [EncodingError, Encoding::ConverterNotFoundError] # and so on

--- a/test/test_mechanize_form_field.rb
+++ b/test/test_mechanize_form_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormField < Mechanize::TestCase

--- a/test/test_mechanize_form_file_upload.rb
+++ b/test/test_mechanize_form_file_upload.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormFileUpload < Mechanize::TestCase

--- a/test/test_mechanize_form_image_button.rb
+++ b/test/test_mechanize_form_image_button.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormImageButton < Mechanize::TestCase

--- a/test/test_mechanize_form_keygen.rb
+++ b/test/test_mechanize_form_keygen.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormKeygen < Mechanize::TestCase

--- a/test/test_mechanize_form_multi_select_list.rb
+++ b/test/test_mechanize_form_multi_select_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormMultiSelectList < Mechanize::TestCase

--- a/test/test_mechanize_form_option.rb
+++ b/test/test_mechanize_form_option.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormOption < Mechanize::TestCase

--- a/test/test_mechanize_form_radio_button.rb
+++ b/test/test_mechanize_form_radio_button.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormRadioButton < Mechanize::TestCase

--- a/test/test_mechanize_form_select_list.rb
+++ b/test/test_mechanize_form_select_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormSelectList < Mechanize::TestCase

--- a/test/test_mechanize_form_textarea.rb
+++ b/test/test_mechanize_form_textarea.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormTextarea < Mechanize::TestCase

--- a/test/test_mechanize_headers.rb
+++ b/test/test_mechanize_headers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHeaders < Mechanize::TestCase

--- a/test/test_mechanize_history.rb
+++ b/test/test_mechanize_history.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHistory < Mechanize::TestCase

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1309,8 +1309,13 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     page = @agent.response_parse @res, body, @uri
 
     assert_instance_of Mechanize::Page, page
-    assert_equal 'UTF8', page.encoding
-    assert_equal 'UTF8', page.parser.encoding
+
+    # as of libxml 2.12.0, the result is dependent on how libiconv is built (which aliases are supported)
+    # if the alias "UTF8" is defined, then the result will be "UTF-8".
+    # if the alias "UTF8" is not defined, then the result will be "UTF8".
+    # note that this alias may be defined by Nokogiri itself in its EncodingHandler class.
+    assert_includes ["UTF8", "UTF-8"], page.encoding
+    assert_includes ["UTF8", "UTF-8"], page.parser.encoding
   end
 
   def test_response_parse_content_type_encoding_garbage

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -576,8 +576,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
   def test_request_language_charset
     @agent.request_language_charset @req
 
-    assert_equal 'en-us,en;q=0.5', @req['accept-language']
-    assert_equal 'ISO-8859-1,utf-8;q=0.7,*;q=0.7', @req['accept-charset']
+    assert_equal('en-us,en;q=0.5', @req['accept-language'])
+    assert_nil(@req['accept-charset'])
   end
 
   def test_request_referer

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -29,7 +29,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
   def skip_if_jruby_zlib
     if RUBY_ENGINE == 'jruby'
-      meth = caller[0][/`(\w+)/, 1]
+      meth = caller_locations(1,1).first.base_label
       skip "#{meth}: skipped because how Zlib handles error is different in JRuby"
     end
   end

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1569,7 +1569,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     refute_includes(headers.keys, "AUTHORIZATION")
     refute_includes(headers.keys, "cookie")
 
-    assert_match 'range|bytes=0-9999', page.body
+    assert_match("range|bytes=0-9999", page.body)
     refute_match("authorization|Basic xxx", page.body)
     refute_match("cookie|name=value", page.body)
   end
@@ -1590,8 +1590,29 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     assert_includes(headers.keys, "AUTHORIZATION")
     assert_includes(headers.keys, "cookie")
 
-    assert_match 'range|bytes=0-9999', page.body
+    assert_match("range|bytes=0-9999", page.body)
     assert_match("authorization|Basic xxx", page.body)
+    assert_match("cookie|name=value", page.body)
+  end
+
+  def test_response_redirect_to_same_site_diff_port_with_credential
+    @agent.redirect_ok = true
+
+    headers = {
+      'Range' => 'bytes=0-9999',
+      'AUTHORIZATION' => 'Basic xxx',
+      'cookie' => 'name=value',
+    }
+
+    page = html_page ''
+    page = @agent.response_redirect({ 'Location' => 'http://example:81/http_headers' }, :get,
+                                    page, 0, headers)
+
+    refute_includes(headers.keys, "AUTHORIZATION")
+    assert_includes(headers.keys, "cookie")
+
+    assert_match("range|bytes=0-9999", page.body)
+    refute_match("authorization|Basic xxx", page.body)
     assert_match("cookie|name=value", page.body)
   end
 

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -27,13 +27,10 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     realm
   end
 
-  def jruby_zlib?
+  def skip_if_jruby_zlib
     if RUBY_ENGINE == 'jruby'
       meth = caller[0][/`(\w+)/, 1]
-      warn "#{meth}: skipped because how Zlib handles error is different in JRuby"
-      true
-    else
-      false
+      skip "#{meth}: skipped because how Zlib handles error is different in JRuby"
     end
   end
 
@@ -823,7 +820,11 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     @res.instance_variable_set(:@header,
                                'www-authenticate' => ['Negotiate, NTLM'])
 
-    page = @agent.response_authenticate @res, nil, @uri, @req, {}, nil, nil
+    begin
+      page = @agent.response_authenticate @res, nil, @uri, @req, {}, nil, nil
+    rescue OpenSSL::Digest::DigestError
+      skip "It looks like OpenSSL is not configured to support MD4"
+    end
 
     assert_equal 'ok', page.body # lame test
   end
@@ -931,7 +932,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     body_io = StringIO.new \
       "\037\213\b\0002\002\225M\000\003+H,*\001"
 
-    skip if jruby_zlib?
+    skip_if_jruby_zlib
 
     e = assert_raises Mechanize::Error do
       @agent.response_content_encoding @res, body_io
@@ -965,7 +966,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     assert_match %r%invalid compressed data -- crc error%, log.string
   rescue IOError
-    raise unless jruby_zlib?
+    skip_if_jruby_zlib
+    raise
   end
 
   def test_response_content_encoding_gzip_checksum_corrupt_length
@@ -983,7 +985,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     assert_match %r%invalid compressed data -- length error%, log.string
   rescue IOError
-    raise unless jruby_zlib?
+    skip_if_jruby_zlib
+    raise
   end
 
   def test_response_content_encoding_gzip_checksum_truncated
@@ -1001,7 +1004,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     assert_match %r%unable to gunzip response: footer is not found%, log.string
   rescue IOError
-    raise unless jruby_zlib?
+    skip_if_jruby_zlib
+    raise
   end
 
   def test_response_content_encoding_gzip_empty
@@ -1042,7 +1046,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     assert body_io.closed?
   rescue IOError
-    raise unless jruby_zlib?
+    skip_if_jruby_zlib
+    raise
   end
 
   def test_response_content_encoding_none

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 
@@ -1027,7 +1028,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     body = @agent.response_content_encoding @res, body_io
 
-    expected = "test\xB2"
+    expected = +"test\xB2"
     expected.force_encoding Encoding::BINARY if have_encoding?
 
     content = body.read
@@ -1432,11 +1433,11 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
       io = @agent.response_read res, req, uri
 
-      expected = "π\n".force_encoding(Encoding::BINARY)
+      expected = "π\n".dup.force_encoding(Encoding::BINARY)
 
       # Ruby 1.8.7 doesn't let us set the write mode of the tempfile to binary,
       # so we should expect an inserted carriage return on some platforms
-      expected_with_carriage_return = "π\r\n".force_encoding(Encoding::BINARY)
+      expected_with_carriage_return = "π\r\n".dup.force_encoding(Encoding::BINARY)
 
       body = io.read
       assert_match(/^(#{expected}|#{expected_with_carriage_return})$/m, body)

--- a/test/test_mechanize_http_auth_challenge.rb
+++ b/test/test_mechanize_http_auth_challenge.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHttpAuthChallenge < Mechanize::TestCase

--- a/test/test_mechanize_http_auth_realm.rb
+++ b/test/test_mechanize_http_auth_realm.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHttpAuthRealm < Mechanize::TestCase

--- a/test/test_mechanize_http_auth_store.rb
+++ b/test/test_mechanize_http_auth_store.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 

--- a/test/test_mechanize_http_content_disposition_parser.rb
+++ b/test/test_mechanize_http_content_disposition_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHttpContentDispositionParser < Mechanize::TestCase

--- a/test/test_mechanize_http_www_authenticate_parser.rb
+++ b/test/test_mechanize_http_www_authenticate_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHttpWwwAuthenticateParser < Mechanize::TestCase

--- a/test/test_mechanize_image.rb
+++ b/test/test_mechanize_image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeImage < Mechanize::TestCase

--- a/test/test_mechanize_link.rb
+++ b/test/test_mechanize_link.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeLink < Mechanize::TestCase

--- a/test/test_mechanize_page.rb
+++ b/test/test_mechanize_page.rb
@@ -276,5 +276,19 @@ class TestMechanizePage < Mechanize::TestCase
 		assert_equal page.title, "HTML>TITLE"
 	end
 
+  def test_frozen_string_body
+    html = (<<~HTML).freeze
+      <html>
+        <head>
+          <title>Page Title</title>
+        </head>
+        <body>
+          <p>Hello World</p>
+        </body>
+      </html>
+    HTML
+
+    html_page(html) # refute_raises
+  end
 end
 

--- a/test/test_mechanize_page.rb
+++ b/test/test_mechanize_page.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePage < Mechanize::TestCase

--- a/test/test_mechanize_page_encoding.rb
+++ b/test/test_mechanize_page_encoding.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 # tests for Page encoding and charset and parsing
@@ -12,7 +13,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
 
     @uri = URI('http://localhost/')
     @response_headers = { 'content-type' => 'text/html' }
-    @body = '<title>hi</title>'
+    @body = +'<title>hi</title>'
   end
 
   def util_page body = @body, headers = @response_headers
@@ -118,7 +119,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
   end
 
   def test_meta_charset
-    body = '<meta http-equiv="content-type" content="text/html;charset=META">'
+    body = +'<meta http-equiv="content-type" content="text/html;charset=META">'
     page = util_page body
 
     assert_equal ['META'], page.meta_charset
@@ -132,7 +133,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
 
   def test_encodings
     response = {'content-type' => 'text/html;charset=HEADER'}
-    body = '<meta http-equiv="content-type" content="text/html;charset=META">'
+    body = +'<meta http-equiv="content-type" content="text/html;charset=META">'
     @mech.default_encoding = 'DEFAULT'
     page = util_page body, response
 
@@ -175,7 +176,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
   def test_parser_encoding_when_searching_elements
     skip "Encoding not implemented" unless have_encoding?
 
-    body = '<span id="latin1">hi</span>'
+    body = +'<span id="latin1">hi</span>'
     page = util_page body, 'content-type' => 'text/html,charset=ISO-8859-1'
 
     result = page.search('#latin1')
@@ -187,7 +188,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
     skip if RUBY_ENGINE == 'jruby' # this is a libxml2-specific condition
 
     # https://github.com/sparklemotion/mechanize/issues/553
-    body = <<~EOF
+    body = +<<~EOF
       <html>
       <body>
       <!--

--- a/test/test_mechanize_page_frame.rb
+++ b/test/test_mechanize_page_frame.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePageFrame < Mechanize::TestCase

--- a/test/test_mechanize_page_image.rb
+++ b/test/test_mechanize_page_image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePageImage < Mechanize::TestCase

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -114,13 +114,12 @@ class TestMechanizePageLink < Mechanize::TestCase
 
     # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
     skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
-    expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
     page = util_page UTF8.dup
 
     assert_equal false, page.encoding_error?
 
-    assert_equal expected_encoding, page.encoding
+    assert_equal "UTF-8", page.encoding
   end
 
   def test_encoding_charset_after_title_double_bad
@@ -138,7 +137,6 @@ class TestMechanizePageLink < Mechanize::TestCase
 
     # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
     skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
-    expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
     page = util_page(+"<title>#{UTF8_TITLE}</title>")
     page.encodings.replace %w[
@@ -148,7 +146,7 @@ class TestMechanizePageLink < Mechanize::TestCase
 
     assert_equal false, page.encoding_error?
 
-    assert_equal expected_encoding, page.encoding
+    assert_equal 'UTF-8', page.encoding
   end
 
   def test_encoding_meta_charset

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -1,8 +1,8 @@
 # coding: utf-8
 
-puts "Nokogiri::VERSION_INFO: #{Nokogiri::VERSION_INFO}"
-
 require 'mechanize/test_case'
+
+puts "Nokogiri::VERSION_INFO: #{Nokogiri::VERSION_INFO}"
 
 class TestMechanizePageLink < Mechanize::TestCase
 

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -51,13 +51,10 @@ class TestMechanizePageLink < Mechanize::TestCase
     Mechanize::Page.new @uri, res, body && body.force_encoding(Encoding::BINARY), 200, @mech
   end
 
-  def nkf_dependency?
-    if RUBY_ENGINE == 'ruby'
-      false
-    else
+  def skip_if_nkf_dependency
+    if RUBY_ENGINE == 'jruby'
       meth = caller[0][/`(\w+)/, 1]
-      warn "#{meth}: skipped because this feature currently depends on NKF"
-      true
+      skip "#{meth}: skipped because this feature currently depends on NKF"
     end
   end
 
@@ -112,7 +109,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding_charset_after_title_bad
-    return if nkf_dependency?
+    skip_if_nkf_dependency
 
     page = util_page UTF8
 
@@ -122,7 +119,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding_charset_after_title_double_bad
-    return if nkf_dependency?
+    skip_if_nkf_dependency
 
     page = util_page SJIS_BAD_AFTER_TITLE
 
@@ -132,7 +129,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding_charset_bad
-    return if nkf_dependency?
+    skip_if_nkf_dependency
 
     page = util_page "<title>#{UTF8_TITLE}</title>"
     page.encodings.replace %w[

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 
@@ -11,7 +12,7 @@ class TestMechanizePageLink < Mechanize::TestCase
 <title>hi</title>
   HTML
 
-  BAD = <<-HTML
+  BAD = <<-HTML.dup
 <meta http-equiv="content-type" content="text/html; charset=windows-1255">
 <title>Bia\xB3ystok</title>
   HTML
@@ -19,18 +20,16 @@ class TestMechanizePageLink < Mechanize::TestCase
 
   SJIS_TITLE = "\x83\x65\x83\x58\x83\x67"
 
-  SJIS_AFTER_TITLE = <<-HTML
+  SJIS_AFTER_TITLE = <<-HTML.dup
 <title>#{SJIS_TITLE}</title>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
   HTML
-
   SJIS_AFTER_TITLE.force_encoding Encoding::BINARY if defined? Encoding
 
-  SJIS_BAD_AFTER_TITLE = <<-HTML
+  SJIS_BAD_AFTER_TITLE = <<-HTML.dup
 <title>#{SJIS_TITLE}</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   HTML
-
   SJIS_BAD_AFTER_TITLE.force_encoding Encoding::BINARY if defined? Encoding
 
   UTF8_TITLE = 'テスト'
@@ -46,7 +45,7 @@ class TestMechanizePageLink < Mechanize::TestCase
 
     @uri = URI('http://example')
     @res = { 'content-type' => 'text/html' }
-    @body = '<title>hi</title>'
+    @body = +'<title>hi</title>'
   end
 
   def util_page body = @body, res = @res
@@ -75,7 +74,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_canonical_uri_unescaped
-    page = util_page <<-BODY
+    page = util_page(+<<-BODY)
 <head>
   <link rel="canonical" href="http://example/white space"/>
 </head>
@@ -97,7 +96,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding
-    page = util_page WINDOWS_1255
+    page = util_page WINDOWS_1255.dup
 
     assert_equal 'windows-1255', page.encoding
   end
@@ -117,7 +116,7 @@ class TestMechanizePageLink < Mechanize::TestCase
     skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
     expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
-    page = util_page UTF8
+    page = util_page UTF8.dup
 
     assert_equal false, page.encoding_error?
 
@@ -141,7 +140,7 @@ class TestMechanizePageLink < Mechanize::TestCase
     skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
     expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
-    page = util_page "<title>#{UTF8_TITLE}</title>"
+    page = util_page(+"<title>#{UTF8_TITLE}</title>")
     page.encodings.replace %w[
       UTF-8
       Shift_JIS
@@ -153,7 +152,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding_meta_charset
-    page = util_page "<meta charset='UTF-8'>"
+    page = util_page(+"<meta charset='UTF-8'>")
 
     assert_equal 'UTF-8', page.encoding
   end
@@ -344,7 +343,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_title_none
-    page = util_page '' # invalid HTML
+    page = util_page(+'') # invalid HTML
 
     assert_nil(page.title)
   end

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -114,7 +114,7 @@ class TestMechanizePageLink < Mechanize::TestCase
     skip_if_nkf_dependency
 
     # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
-    skip if Nokogiri.uses_libxml?([">= 2.11.0", "<= 2.11.4"])
+    skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
     expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
     page = util_page UTF8
@@ -138,7 +138,7 @@ class TestMechanizePageLink < Mechanize::TestCase
     skip_if_nkf_dependency
 
     # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
-    skip if Nokogiri.uses_libxml?([">= 2.11.0", "<= 2.11.4"])
+    skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
     expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
     page = util_page "<title>#{UTF8_TITLE}</title>"

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -55,7 +55,7 @@ class TestMechanizePageLink < Mechanize::TestCase
 
   def skip_if_nkf_dependency
     if RUBY_ENGINE == 'jruby'
-      meth = caller[0][/`(\w+)/, 1]
+      meth = caller_locations(1,1).first.base_label
       skip "#{meth}: skipped because this feature currently depends on NKF"
     end
   end

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+puts "Nokogiri::VERSION_INFO: #{Nokogiri::VERSION_INFO}"
+
 require 'mechanize/test_case'
 
 class TestMechanizePageLink < Mechanize::TestCase
@@ -111,11 +113,15 @@ class TestMechanizePageLink < Mechanize::TestCase
   def test_encoding_charset_after_title_bad
     skip_if_nkf_dependency
 
+    # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
+    skip if Nokogiri.uses_libxml?([">= 2.11.0", "<= 2.11.4"])
+    expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
+
     page = util_page UTF8
 
     assert_equal false, page.encoding_error?
 
-    assert_equal 'UTF-8', page.encoding
+    assert_equal expected_encoding, page.encoding
   end
 
   def test_encoding_charset_after_title_double_bad
@@ -131,6 +137,10 @@ class TestMechanizePageLink < Mechanize::TestCase
   def test_encoding_charset_bad
     skip_if_nkf_dependency
 
+    # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
+    skip if Nokogiri.uses_libxml?([">= 2.11.0", "<= 2.11.4"])
+    expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
+
     page = util_page "<title>#{UTF8_TITLE}</title>"
     page.encodings.replace %w[
       UTF-8
@@ -139,7 +149,7 @@ class TestMechanizePageLink < Mechanize::TestCase
 
     assert_equal false, page.encoding_error?
 
-    assert_equal 'UTF-8', page.encoding
+    assert_equal expected_encoding, page.encoding
   end
 
   def test_encoding_meta_charset

--- a/test/test_mechanize_page_meta_refresh.rb
+++ b/test/test_mechanize_page_meta_refresh.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePageMetaRefresh < Mechanize::TestCase

--- a/test/test_mechanize_parser.rb
+++ b/test/test_mechanize_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeParser < Mechanize::TestCase

--- a/test/test_mechanize_pluggable_parser.rb
+++ b/test/test_mechanize_pluggable_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePluggableParser < Mechanize::TestCase

--- a/test/test_mechanize_redirect_limit_reached_error.rb
+++ b/test/test_mechanize_redirect_limit_reached_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeRedirectLimitReachedError < Mechanize::TestCase

--- a/test/test_mechanize_redirect_not_get_or_head_error.rb
+++ b/test/test_mechanize_redirect_not_get_or_head_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeRedirectNotGetOrHead < Mechanize::TestCase

--- a/test/test_mechanize_response_read_error.rb
+++ b/test/test_mechanize_response_read_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeResponseReadError < Mechanize::TestCase

--- a/test/test_mechanize_subclass.rb
+++ b/test/test_mechanize_subclass.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeSubclass < Mechanize::TestCase

--- a/test/test_mechanize_util.rb
+++ b/test/test_mechanize_util.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 
@@ -6,7 +7,7 @@ class TestMechanizeUtil < Mechanize::TestCase
 
   INPUTTED_VALUE = "テスト" # "test" in Japanese UTF-8 encoding
   CONTENT_ENCODING = 'Shift_JIS' # one of Japanese encoding
-  ENCODED_VALUE = "\x83\x65\x83\x58\x83\x67".force_encoding(::Encoding::SHIFT_JIS) # "test" in Japanese Shift_JIS encoding
+  ENCODED_VALUE = "\x83\x65\x83\x58\x83\x67".dup.force_encoding(::Encoding::SHIFT_JIS) # "test" in Japanese Shift_JIS encoding
 
   ENCODING_ERRORS = [EncodingError, Encoding::ConverterNotFoundError] # and so on
   ERROR_LOG_MESSAGE = /from_native_charset: Encoding::ConverterNotFoundError: form encoding: "UTF-eight"/
@@ -67,7 +68,7 @@ class TestMechanizeUtil < Mechanize::TestCase
   end
 
   def test_from_native_charset_logs_form_when_encoding_error_raised
-    sio = StringIO.new("")
+    sio = StringIO.new
     log = Logger.new(sio)
     log.level = Logger::DEBUG
 
@@ -79,7 +80,7 @@ class TestMechanizeUtil < Mechanize::TestCase
   end
 
   def test_from_native_charset_logs_form_when_encoding_error_is_ignored
-    sio = StringIO.new("")
+    sio = StringIO.new
     log = Logger.new(sio)
     log.level = Logger::DEBUG
 

--- a/test/test_mechanize_xml_file.rb
+++ b/test/test_mechanize_xml_file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeXmlFile < Mechanize::TestCase

--- a/test/test_multi_select.rb
+++ b/test/test_multi_select.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class MultiSelectTest < Mechanize::TestCase


### PR DESCRIPTION
`Net::HTTP::Persistent.write_timeout` now exposes [Net::HTTP.write_timeout](https://docs.ruby-lang.org/en/master/Net/HTTP.html#attribute-i-write_timeout) since https://github.com/drbrain/net-http-persistent/pull/99