### PR TITLE
fix: clear credentials when redirecting to a different port

### DIFF
--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1569,7 +1569,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     refute_includes(headers.keys, "AUTHORIZATION")
     refute_includes(headers.keys, "cookie")
 
-    assert_match 'range|bytes=0-9999', page.body
+    assert_match("range|bytes=0-9999", page.body)
     refute_match("authorization|Basic xxx", page.body)
     refute_match("cookie|name=value", page.body)
   end
@@ -1590,8 +1590,29 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     assert_includes(headers.keys, "AUTHORIZATION")
     assert_includes(headers.keys, "cookie")
 
-    assert_match 'range|bytes=0-9999', page.body
+    assert_match("range|bytes=0-9999", page.body)
     assert_match("authorization|Basic xxx", page.body)
+    assert_match("cookie|name=value", page.body)
+  end
+
+  def test_response_redirect_to_same_site_diff_port_with_credential
+    @agent.redirect_ok = true
+
+    headers = {
+      'Range' => 'bytes=0-9999',
+      'AUTHORIZATION' => 'Basic xxx',
+      'cookie' => 'name=value',
+    }
+
+    page = html_page ''
+    page = @agent.response_redirect({ 'Location' => 'http://example:81/http_headers' }, :get,
+                                    page, 0, headers)
+
+    refute_includes(headers.keys, "AUTHORIZATION")
+    assert_includes(headers.keys, "cookie")
+
+    assert_match("range|bytes=0-9999", page.body)
+    refute_match("authorization|Basic xxx", page.body)
     assert_match("cookie|name=value", page.body)
   end
 


### PR DESCRIPTION
Note that in this case we treat cookies differently from credentials
per RFC 6265 section 8.5:

https://datatracker.ietf.org/doc/html/rfc6265#section-8.5

> Cookies do not provide isolation by port.  If a cookie is readable
> by a service running on one port, the cookie is also readable by a
> service running on another port of the same server.  If a cookie is
> writable by a service on one port, the cookie is also writable by a
> service running on another port of the same server.  For this
> reason, servers SHOULD NOT both run mutually distrusting services on
> different ports of the same host and use cookies to store security-
> sensitive information.

@kyoshidajp, would love your feedback on this.