### PR TITLE
ci: include ruby 3.2, get back to green

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -31,7 +31,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby", "truffleruby-head"]
+        # TODO update jruby once 9.4.1.0 is out
+        # 9.4.0.0 is affected by https://github.com/jruby/jruby/issues/7481
+        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.3", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,5 +1,9 @@
 name: "ci"
 
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -8,6 +12,8 @@ on:
     types: [opened, synchronize]
     branches:
       - main
+  schedule:
+    - cron: "0 8 * * 5" # At 08:00 on Friday # https://crontab.guru/#0_8_*_*_5
 
 jobs:
   rubocop:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.1"
+        ruby-version: "3.2"
         bundler-cache: true
     - run: bundle exec rake rubocop
 
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "head", "jruby", "truffleruby-head"]
+        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +48,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.1"
+        ruby-version: "3.2"
         bundler-cache: true
     - run: bundle exec rake test

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -27,13 +27,10 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     realm
   end
 
-  def jruby_zlib?
+  def skip_if_jruby_zlib
     if RUBY_ENGINE == 'jruby'
       meth = caller[0][/`(\w+)/, 1]
-      warn "#{meth}: skipped because how Zlib handles error is different in JRuby"
-      true
-    else
-      false
+      skip "#{meth}: skipped because how Zlib handles error is different in JRuby"
     end
   end
 
@@ -935,7 +932,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     body_io = StringIO.new \
       "\037\213\b\0002\002\225M\000\003+H,*\001"
 
-    skip if jruby_zlib?
+    skip_if_jruby_zlib
 
     e = assert_raises Mechanize::Error do
       @agent.response_content_encoding @res, body_io
@@ -969,7 +966,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     assert_match %r%invalid compressed data -- crc error%, log.string
   rescue IOError
-    raise unless jruby_zlib?
+    skip_if_jruby_zlib
+    raise
   end
 
   def test_response_content_encoding_gzip_checksum_corrupt_length
@@ -987,7 +985,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     assert_match %r%invalid compressed data -- length error%, log.string
   rescue IOError
-    raise unless jruby_zlib?
+    skip_if_jruby_zlib
+    raise
   end
 
   def test_response_content_encoding_gzip_checksum_truncated
@@ -1005,7 +1004,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     assert_match %r%unable to gunzip response: footer is not found%, log.string
   rescue IOError
-    raise unless jruby_zlib?
+    skip_if_jruby_zlib
+    raise
   end
 
   def test_response_content_encoding_gzip_empty
@@ -1046,7 +1046,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     assert body_io.closed?
   rescue IOError
-    raise unless jruby_zlib?
+    skip_if_jruby_zlib
+    raise
   end
 
   def test_response_content_encoding_none

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -823,7 +823,11 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     @res.instance_variable_set(:@header,
                                'www-authenticate' => ['Negotiate, NTLM'])
 
-    page = @agent.response_authenticate @res, nil, @uri, @req, {}, nil, nil
+    begin
+      page = @agent.response_authenticate @res, nil, @uri, @req, {}, nil, nil
+    rescue OpenSSL::Digest::DigestError
+      skip "It looks like OpenSSL is not configured to support MD4"
+    end
 
     assert_equal 'ok', page.body # lame test
   end

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -51,13 +51,10 @@ class TestMechanizePageLink < Mechanize::TestCase
     Mechanize::Page.new @uri, res, body && body.force_encoding(Encoding::BINARY), 200, @mech
   end
 
-  def nkf_dependency?
-    if RUBY_ENGINE == 'ruby'
-      false
-    else
+  def skip_if_nkf_dependency
+    if RUBY_ENGINE == 'jruby'
       meth = caller[0][/`(\w+)/, 1]
-      warn "#{meth}: skipped because this feature currently depends on NKF"
-      true
+      skip "#{meth}: skipped because this feature currently depends on NKF"
     end
   end
 
@@ -112,7 +109,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding_charset_after_title_bad
-    return if nkf_dependency?
+    skip_if_nkf_dependency
 
     page = util_page UTF8
 
@@ -122,7 +119,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding_charset_after_title_double_bad
-    return if nkf_dependency?
+    skip_if_nkf_dependency
 
     page = util_page SJIS_BAD_AFTER_TITLE
 
@@ -132,7 +129,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding_charset_bad
-    return if nkf_dependency?
+    skip_if_nkf_dependency
 
     page = util_page "<title>#{UTF8_TITLE}</title>"
     page.encodings.replace %w[


### PR DESCRIPTION
- Update CI to test with Ruby 3.2
- Pin JRuby until the frozen string fix in https://github.com/jruby/jruby/issues/7481 is released
- Skip NTLM tests for modern OpenSSL installations
- Run the tests in a weekly cron job to prevent bitrot going forward