### PR TITLE
drop ruby 2.5 support

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.4", "truffleruby-head"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.4", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Mechanize CHANGELOG
 
+## next / unreleased
+
+### Requirements
+
+* Mechanize now requires Ruby 2.6 or newer.
+
+
 ## 2.8.5 / 2022-06-09
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Mechanize library is used for automating interaction with websites. Mechaniz
 
 ## Dependencies
 
-* Ruby >= 2.5
+* Ruby >= 2.6
 * Gems:
   * `addressable`
   * `domain_name`

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files += Dir['*.rdoc', '*.md']
   spec.rdoc_options = ["--main", "README.md"]
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_runtime_dependency("addressable", "~> 2.8")
   spec.add_runtime_dependency("domain_name", ">= 0.5.20190701", "~> 0.5")


### PR DESCRIPTION
ruby 2.5 started failing in CI again, and I just don't have the energy to try to fix it.

https://github.com/sparklemotion/mechanize/actions/runs/4382526288/jobs/7741821736#step:3:346

It's time.