### PR TITLE
fix: allow frozen string body argument on Mechanize::Page#initialize

### DIFF
--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -41,6 +41,8 @@ class Mechanize::Page < Mechanize::File
     @encodings.concat self.class.response_header_charset(response)
 
     if body
+      body = +body
+
       # Force the encoding to be 8BIT so we can perform regular expressions.
       # We'll set it to the detected encoding later
       body.force_encoding(Encoding::ASCII_8BIT)

--- a/test/test_mechanize_page.rb
+++ b/test/test_mechanize_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mechanize/test_case'
 
 class TestMechanizePage < Mechanize::TestCase


### PR DESCRIPTION
[`Mechanize::Page#initialize` calls `String#force_encoding`](https://github.com/sparklemotion/mechanize/blob/v2.8.5/lib/mechanize/page.rb#L46), so `FrozenError` is occurred.

This pull-request fixes it.

---

On mechanize-2.8.5 (and currently main branch 4c8d3d2263c091b4ffe8e981b6776e5ae7cb80c9 ), I saw following:

```console
$ cat a.rb
# frozen_string_literal: true

require "mechanize"

Mechanize::Page.new(
  URI("https://example.org"),
  nil,
  "page content", # this argument!
  200,
  Mechanize.new,
)
$ ruby a.rb
/home/yuya/.anyenv/envs/rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/mechanize-2.8.5/lib/mechanize/page.rb:46:in `force_encoding': can't modify frozen String: "page content" (FrozenError)
        from /home/yuya/.anyenv/envs/rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/mechanize-2.8.5/lib/mechanize/page.rb:46:in `initialize'
        from a.rb:5:in `new'
        from a.rb:5:in `<main>'
```
