### PR TITLE
fix: stop force_encoding the page body

### DIFF
--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -41,10 +41,6 @@ class Mechanize::Page < Mechanize::File
     @encodings.concat self.class.response_header_charset(response)
 
     if body
-      # Force the encoding to be 8BIT so we can perform regular expressions.
-      # We'll set it to the detected encoding later
-      body.force_encoding(Encoding::ASCII_8BIT)
-
       @encodings.concat self.class.meta_charset body
 
       meta_content_type = self.class.meta_content_type body

--- a/test/test_mechanize_page.rb
+++ b/test/test_mechanize_page.rb
@@ -276,5 +276,19 @@ class TestMechanizePage < Mechanize::TestCase
 		assert_equal page.title, "HTML>TITLE"
 	end
 
+  def test_frozen_string_body
+    html = (<<~HTML).freeze
+      <html>
+        <head>
+          <title>Page Title</title>
+        </head>
+        <body>
+          <p>Hello World</p>
+        </body>
+      </html>
+    HTML
+
+    html_page(html) # refute_raises
+  end
 end
 


### PR DESCRIPTION
which allows us to handle frozen strings

This is an alternative solution to the problem described in #609 