### PR TITLE
test: work around libxml2 encoding changes

### DIFF
--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -114,7 +114,7 @@ class TestMechanizePageLink < Mechanize::TestCase
     skip_if_nkf_dependency
 
     # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
-    skip if Nokogiri.uses_libxml?([">= 2.11.0", "<= 2.11.4"])
+    skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
     expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
     page = util_page UTF8
@@ -138,7 +138,7 @@ class TestMechanizePageLink < Mechanize::TestCase
     skip_if_nkf_dependency
 
     # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
-    skip if Nokogiri.uses_libxml?([">= 2.11.0", "<= 2.11.4"])
+    skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
     expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
     page = util_page "<title>#{UTF8_TITLE}</title>"


### PR DESCRIPTION
Related to #613 and 762df0c7, we're seeing the upstream libxml2 fixes did not ship in v2.11.5 so let's change the version test to assume it won't land until v2.12.0.
