### PR TITLE
ci: test_mechanize_page_link requires nokogiri before using it

### DIFF
--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -1,8 +1,8 @@
 # coding: utf-8
 
-puts "Nokogiri::VERSION_INFO: #{Nokogiri::VERSION_INFO}"
-
 require 'mechanize/test_case'
+
+puts "Nokogiri::VERSION_INFO: #{Nokogiri::VERSION_INFO}"
 
 class TestMechanizePageLink < Mechanize::TestCase
 


### PR DESCRIPTION
For example of a failing test, see https://github.com/sparklemotion/mechanize/actions/runs/6195521653/job/16840196792