### PR TITLE
Explicitly require gems scheduled for removal from ruby stdlib

### DIFF
--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -64,6 +64,7 @@ Gem::Specification.new do |spec|
   # - see use of retry_change_requests that was removed at #558
   spec.add_runtime_dependency("net-http-persistent", ">= 2.5.2", "< 5.0.dev")
 
+  spec.add_runtime_dependency("nkf", "~> 0.1.2")
   spec.add_runtime_dependency("nokogiri", ">= 1.11.2", "~> 1.11")
   spec.add_runtime_dependency("rubyntlm", ">= 0.6.3", "~> 0.6")
   spec.add_runtime_dependency("webrick", "~> 1.7")

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -64,6 +64,7 @@ Gem::Specification.new do |spec|
   # - see use of retry_change_requests that was removed at #558
   spec.add_runtime_dependency("net-http-persistent", ">= 2.5.2", "< 5.0.dev")
 
+  spec.add_runtime_dependency("mutex_m", "~> 0.2")
   spec.add_runtime_dependency("nkf", "~> 0.1.2")
   spec.add_runtime_dependency("nokogiri", ">= 1.11.2", "~> 1.11")
   spec.add_runtime_dependency("rubyntlm", ">= 0.6.3", "~> 0.6")


### PR DESCRIPTION
Helps to avoid a warning: 
```
nkf was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add nkf to your Gemfile or gemspec
```
appearing in ruby 3.3