### PR TITLE
ci: test with ruby 3.3, accommodate new libxml2 behavior

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "head", "jruby-9.4", "truffleruby-head"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "head", "jruby-9.4", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1309,8 +1309,13 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
     page = @agent.response_parse @res, body, @uri
 
     assert_instance_of Mechanize::Page, page
-    assert_equal 'UTF8', page.encoding
-    assert_equal 'UTF8', page.parser.encoding
+
+    # as of libxml 2.12.0, the result is dependent on how libiconv is built (which aliases are supported)
+    # if the alias "UTF8" is defined, then the result will be "UTF-8".
+    # if the alias "UTF8" is not defined, then the result will be "UTF8".
+    # note that this alias may be defined by Nokogiri itself in its EncodingHandler class.
+    assert_includes ["UTF8", "UTF-8"], page.encoding
+    assert_includes ["UTF8", "UTF-8"], page.parser.encoding
   end
 
   def test_response_parse_content_type_encoding_garbage


### PR DESCRIPTION
Add Ruby 3.3 to the test matrix.

Also, update an encoding test to pass with the latest libxml2 (v2.12) delivered by the latest nokogiri (v1.16).