### PR TITLE
dep: ruby 3.4 unbundled gems

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "head", "jruby-9.4", "truffleruby-head"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "jruby-9.4", "truffleruby", "head", "jruby-head", "truffleruby-head"]
 
     runs-on: ubuntu-latest
     steps:

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -65,9 +65,12 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("net-http-persistent", ">= 2.5.2", "< 5.0.dev")
 
   spec.add_runtime_dependency("nokogiri", ">= 1.11.2", "~> 1.11")
-  spec.add_runtime_dependency("rubyntlm", ">= 0.6.3", "~> 0.6")
   spec.add_runtime_dependency("webrick", "~> 1.7")
   spec.add_runtime_dependency("webrobots", "~> 0.1.2")
+
+  spec.add_runtime_dependency("rubyntlm", ">= 0.6.3", "~> 0.6")
+  spec.add_runtime_dependency("base64") # removed from bundled gems in 3.4, and needed by rubyntlm (which doesn't declare this dependency)
+  spec.add_runtime_dependency("nkf") # removed from bundled gems in 3.4
 
   spec.add_development_dependency("minitest", "~> 5.14")
   spec.add_development_dependency("rake", "~> 13.0")


### PR DESCRIPTION
Explicitly add gems that are unbundled in Ruby 3.4 (that Ruby 3.3 is already warning about):

- nkf is used directly by mechanize
- base64 is used by rubyntlm but that gem does not look maintained

Also: add `truffleruby` (stable) and `jruby-head` to the CI matrix.

Fixes #633 