### PR TITLE
prefer `caller_locations` and `Thread::Backtrace::Location` methods to `Kernel#caller`

### DIFF
--- a/lib/mechanize.rb
+++ b/lib/mechanize.rb
@@ -717,10 +717,10 @@ class Mechanize
   # authentication.
 
   def auth user, password, domain = nil
-    caller.first =~ /(.*?):(\d+).*?$/
+    c = caller_locations(1,1).first
 
     warn <<-WARNING
-At #{$1} line #{$2}
+At #{c.absolute_path} line #{c.lineno}
 
 Use of #auth and #basic_auth are deprecated due to a security vulnerability.
 

--- a/lib/mechanize/cookie.rb
+++ b/lib/mechanize/cookie.rb
@@ -7,7 +7,7 @@ class Mechanize
   module CookieDeprecated
     def __deprecated__(to = nil)
       $VERBOSE or return
-      method = caller[0][/([^`]+)(?='$)/]
+      method = caller_locations(1,1).first.base_label
       to ||= method
       case self
       when Class
@@ -21,7 +21,7 @@ class Mechanize
         this = '%s#%s' % [klass, method]
         that = 'HTTP::%s#%s' % [lname, to]
       end
-      warn '%s: The call of %s needs to be fixed to follow the new API (%s).' % [caller[1], this, that]
+      warn '%s: The call of %s needs to be fixed to follow the new API (%s).' % [caller_locations(2,1).first, this, that]
     end
     private :__deprecated__
   end

--- a/test/test_mechanize_cookie.rb
+++ b/test/test_mechanize_cookie.rb
@@ -502,12 +502,23 @@ class TestMechanizeCookie < Mechanize::TestCase
     cookie.domain = 'Dom.example.com'
     assert 'dom.example.com', cookie.domain
 
-    cookie.domain = Object.new.tap { |o|
+    new_domain = Object.new.tap { |o|
       def o.to_str
         'Example.com'
       end
     }
+    cookie.domain = new_domain
     assert 'example.com', cookie.domain
+
+    new_domain = Object.new.tap { |o|
+      def o.to_str
+        'Example2.com'
+      end
+    }
+    assert_output nil, /The call of Mechanize::Cookie#set_domain/ do
+      cookie.set_domain(new_domain)
+    end
+    assert 'example2.com', cookie.domain
   end
 
   def test_cookie_httponly

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -29,7 +29,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
   def skip_if_jruby_zlib
     if RUBY_ENGINE == 'jruby'
-      meth = caller[0][/`(\w+)/, 1]
+      meth = caller_locations(1,1).first.base_label
       skip "#{meth}: skipped because how Zlib handles error is different in JRuby"
     end
   end

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -55,7 +55,7 @@ class TestMechanizePageLink < Mechanize::TestCase
 
   def skip_if_nkf_dependency
     if RUBY_ENGINE == 'jruby'
-      meth = caller[0][/`(\w+)/, 1]
+      meth = caller_locations(1,1).first.base_label
       skip "#{meth}: skipped because this feature currently depends on NKF"
     end
   end


### PR DESCRIPTION
Mechanize has still been using `Kernel#caller` whose string representation has changed enough in Ruby 3.4.0.dev to break how deprecation messages were being handrolled.

Replace all uses of `caller` with `caller_locations` which is both faster and returns an object with some nice methods we can use to isolate the method, the file, and the line number.

This should get us green again on ruby-head.