### PR TITLE
ci: extract upstream pipeline, start integration testing against nokogiri main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
     - run: bundle exec rake rubocop
 
@@ -36,27 +36,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby-version}}
         bundler-cache: true
-        bundler: 2.3.26 # https://github.com/rubygems/rubygems/issues/6435
-    - run: bundle exec rake test
-
-  test-platform:
-    needs: ["rubocop"]
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ["windows-latest", "macos-latest"]
-
-    runs-on: ${{matrix.platform}}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: "3.2"
-        bundler-cache: true
-        bundler: latest
     - run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "jruby-9.4", "truffleruby", "head", "jruby-head", "truffleruby-head"]
-
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "jruby-9.4", "truffleruby"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,4 +1,4 @@
-name: "ci"
+name: "upstream"
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
@@ -19,7 +19,16 @@ on:
       - .github/workflows/upstream.yml # this file
 
 jobs:
-  skeleton:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ["head", "jruby-head", "truffleruby-head"]
     runs-on: ubuntu-latest
     steps:
-    - run: echo "Hello, World!"
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{matrix.ruby-version}}
+        bundler-cache: true
+    - run: bundle exec rake test

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -26,9 +26,26 @@ jobs:
         ruby-version: ["head", "jruby-head", "truffleruby-head"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{matrix.ruby-version}}
-        bundler-cache: true
-    - run: bundle exec rake test
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{matrix.ruby-version}}
+          bundler-cache: true
+      - run: bundle exec rake test
+
+  upstream:
+    name: "upstream (${{matrix.name}})"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: "nokogiri", git: "https://github.com/sparklemotion/nokogiri" }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with: { ruby-version: "3.3" }
+      - run: |
+          bundle add ${{matrix.name}} --git="${{matrix.git}}"
+          bundle show
+      - run: bundle exec rake test


### PR DESCRIPTION
update CI pipelines

- update versions of actions
- drop macos and windows builds (which are low value for this gem)
- split out testing of edge rubies to "upstream" pipeline
- add upstream nokogiri integration test