### PR TITLE
test: update tests to use frozen string literals

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ namespace "rubocop" do
 
   desc "Run rubocop string literals check"
   task :frozen_string_literals do
-    sh "rubocop lib --auto-correct-all --only Style/FrozenStringLiteralComment"
+    sh "rubocop lib test --auto-correct-all --only Style/FrozenStringLiteralComment"
   end
 end
 

--- a/test/test_mechanize.rb
+++ b/test/test_mechanize.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 
@@ -965,7 +966,7 @@ but not <a href="/" rel="me nofollow">this</a>!
     })
 
     assert_match(
-      "Content-Disposition: form-data; name=\"userfile1\"; filename=\"#{name}\"".force_encoding(Encoding::ASCII_8BIT),
+      "Content-Disposition: form-data; name=\"userfile1\"; filename=\"#{name}\"".dup.force_encoding(Encoding::ASCII_8BIT),
       page.body
     )
     assert_match("Content-Type: application/zip", page.body)

--- a/test/test_mechanize_cookie.rb
+++ b/test/test_mechanize_cookie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 module Enumerable
@@ -301,7 +302,7 @@ class TestMechanizeCookie < Mechanize::TestCase
     expires = Time.parse('Sun, 27-Sep-2037 00:00:00 GMT')
 
     cookie_params.keys.combine.each do |c|
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -336,7 +337,7 @@ class TestMechanizeCookie < Mechanize::TestCase
     expires = Time.parse('Sun, 27-Sep-2037 00:00:00 GMT')
 
     cookie_params.keys.combine.each do |c|
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -373,7 +374,7 @@ class TestMechanizeCookie < Mechanize::TestCase
 
     cookie_params.keys.combine.each do |c|
       next if c.find { |k| k == 'path' }
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -410,7 +411,7 @@ class TestMechanizeCookie < Mechanize::TestCase
 
     cookie_params.keys.combine.each do |c|
       next unless c.find { |k| k == 'secure' }
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -446,7 +447,7 @@ class TestMechanizeCookie < Mechanize::TestCase
     expires = Time.parse('Sun, 27-Sep-2037 00:00:00 GMT')
 
     cookie_params.keys.combine.each do |c|
-      cookie_text = "#{cookie_value};"
+      cookie_text = +"#{cookie_value};"
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"
@@ -530,7 +531,7 @@ class TestMechanizeCookie < Mechanize::TestCase
     expires = Time.parse('Sun, 27-Sep-2037 00:00:00 GMT')
 
     cookie_params.keys.combine.each do |c|
-      cookie_text = "#{cookie_value}; "
+      cookie_text = +"#{cookie_value}; "
       c.each_with_index do |key, idx|
         if idx == (c.length - 1)
           cookie_text << "#{cookie_params[key]}"

--- a/test/test_mechanize_cookie_jar.rb
+++ b/test/test_mechanize_cookie_jar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 require 'fileutils'
 

--- a/test/test_mechanize_directory_saver.rb
+++ b/test/test_mechanize_directory_saver.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeDirectorySaver < Mechanize::TestCase

--- a/test/test_mechanize_download.rb
+++ b/test/test_mechanize_download.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeDownload < Mechanize::TestCase

--- a/test/test_mechanize_element_not_found_error.rb
+++ b/test/test_mechanize_element_not_found_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeRedirectLimitReachedError < Mechanize::TestCase

--- a/test/test_mechanize_file.rb
+++ b/test/test_mechanize_file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFile < Mechanize::TestCase

--- a/test/test_mechanize_file_connection.rb
+++ b/test/test_mechanize_file_connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFileConnection < Mechanize::TestCase
@@ -7,7 +8,7 @@ class TestMechanizeFileConnection < Mechanize::TestCase
     uri = URI.parse "file://#{file_path}"
     conn = Mechanize::FileConnection.new
 
-    body = ''
+    body = +''
 
     conn.request uri, nil do |response|
       assert_equal(file_path, response.file_path)

--- a/test/test_mechanize_file_request.rb
+++ b/test/test_mechanize_file_request.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFileRequest < Mechanize::TestCase

--- a/test/test_mechanize_file_response.rb
+++ b/test/test_mechanize_file_response.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFileResponse < Mechanize::TestCase

--- a/test/test_mechanize_file_saver.rb
+++ b/test/test_mechanize_file_saver.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFileSaver < Mechanize::TestCase

--- a/test/test_mechanize_form.rb
+++ b/test/test_mechanize_form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeForm < Mechanize::TestCase

--- a/test/test_mechanize_form_check_box.rb
+++ b/test/test_mechanize_form_check_box.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormCheckBox < Mechanize::TestCase

--- a/test/test_mechanize_form_encoding.rb
+++ b/test/test_mechanize_form_encoding.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormEncoding < Mechanize::TestCase
@@ -8,7 +9,7 @@ class TestMechanizeFormEncoding < Mechanize::TestCase
 
   INPUTTED_VALUE = "テスト" # "test" in Japanese UTF-8 encoding
   CONTENT_ENCODING = 'Shift_JIS' # one of Japanese encoding
-  encoded_value = "\x83\x65\x83\x58\x83\x67".force_encoding(::Encoding::SHIFT_JIS) # "test" in Japanese Shift_JIS encoding
+  encoded_value = "\x83\x65\x83\x58\x83\x67".dup.force_encoding(::Encoding::SHIFT_JIS) # "test" in Japanese Shift_JIS encoding
   EXPECTED_QUERY = "first_name=#{CGI.escape(encoded_value)}&first_name=&gender=&green%5Beggs%5D="
 
   ENCODING_ERRORS = [EncodingError, Encoding::ConverterNotFoundError] # and so on

--- a/test/test_mechanize_form_field.rb
+++ b/test/test_mechanize_form_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormField < Mechanize::TestCase

--- a/test/test_mechanize_form_file_upload.rb
+++ b/test/test_mechanize_form_file_upload.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormFileUpload < Mechanize::TestCase

--- a/test/test_mechanize_form_image_button.rb
+++ b/test/test_mechanize_form_image_button.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormImageButton < Mechanize::TestCase

--- a/test/test_mechanize_form_keygen.rb
+++ b/test/test_mechanize_form_keygen.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormKeygen < Mechanize::TestCase

--- a/test/test_mechanize_form_multi_select_list.rb
+++ b/test/test_mechanize_form_multi_select_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormMultiSelectList < Mechanize::TestCase

--- a/test/test_mechanize_form_option.rb
+++ b/test/test_mechanize_form_option.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormOption < Mechanize::TestCase

--- a/test/test_mechanize_form_radio_button.rb
+++ b/test/test_mechanize_form_radio_button.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormRadioButton < Mechanize::TestCase

--- a/test/test_mechanize_form_select_list.rb
+++ b/test/test_mechanize_form_select_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormSelectList < Mechanize::TestCase

--- a/test/test_mechanize_form_textarea.rb
+++ b/test/test_mechanize_form_textarea.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeFormTextarea < Mechanize::TestCase

--- a/test/test_mechanize_headers.rb
+++ b/test/test_mechanize_headers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHeaders < Mechanize::TestCase

--- a/test/test_mechanize_history.rb
+++ b/test/test_mechanize_history.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHistory < Mechanize::TestCase

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 
@@ -1027,7 +1028,7 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
     body = @agent.response_content_encoding @res, body_io
 
-    expected = "test\xB2"
+    expected = +"test\xB2"
     expected.force_encoding Encoding::BINARY if have_encoding?
 
     content = body.read
@@ -1432,11 +1433,11 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
 
       io = @agent.response_read res, req, uri
 
-      expected = "π\n".force_encoding(Encoding::BINARY)
+      expected = "π\n".dup.force_encoding(Encoding::BINARY)
 
       # Ruby 1.8.7 doesn't let us set the write mode of the tempfile to binary,
       # so we should expect an inserted carriage return on some platforms
-      expected_with_carriage_return = "π\r\n".force_encoding(Encoding::BINARY)
+      expected_with_carriage_return = "π\r\n".dup.force_encoding(Encoding::BINARY)
 
       body = io.read
       assert_match(/^(#{expected}|#{expected_with_carriage_return})$/m, body)

--- a/test/test_mechanize_http_auth_challenge.rb
+++ b/test/test_mechanize_http_auth_challenge.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHttpAuthChallenge < Mechanize::TestCase

--- a/test/test_mechanize_http_auth_realm.rb
+++ b/test/test_mechanize_http_auth_realm.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHttpAuthRealm < Mechanize::TestCase

--- a/test/test_mechanize_http_auth_store.rb
+++ b/test/test_mechanize_http_auth_store.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 

--- a/test/test_mechanize_http_content_disposition_parser.rb
+++ b/test/test_mechanize_http_content_disposition_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHttpContentDispositionParser < Mechanize::TestCase

--- a/test/test_mechanize_http_www_authenticate_parser.rb
+++ b/test/test_mechanize_http_www_authenticate_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeHttpWwwAuthenticateParser < Mechanize::TestCase

--- a/test/test_mechanize_image.rb
+++ b/test/test_mechanize_image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeImage < Mechanize::TestCase

--- a/test/test_mechanize_link.rb
+++ b/test/test_mechanize_link.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeLink < Mechanize::TestCase

--- a/test/test_mechanize_page.rb
+++ b/test/test_mechanize_page.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePage < Mechanize::TestCase

--- a/test/test_mechanize_page_encoding.rb
+++ b/test/test_mechanize_page_encoding.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 # tests for Page encoding and charset and parsing
@@ -12,7 +13,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
 
     @uri = URI('http://localhost/')
     @response_headers = { 'content-type' => 'text/html' }
-    @body = '<title>hi</title>'
+    @body = +'<title>hi</title>'
   end
 
   def util_page body = @body, headers = @response_headers
@@ -118,7 +119,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
   end
 
   def test_meta_charset
-    body = '<meta http-equiv="content-type" content="text/html;charset=META">'
+    body = +'<meta http-equiv="content-type" content="text/html;charset=META">'
     page = util_page body
 
     assert_equal ['META'], page.meta_charset
@@ -132,7 +133,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
 
   def test_encodings
     response = {'content-type' => 'text/html;charset=HEADER'}
-    body = '<meta http-equiv="content-type" content="text/html;charset=META">'
+    body = +'<meta http-equiv="content-type" content="text/html;charset=META">'
     @mech.default_encoding = 'DEFAULT'
     page = util_page body, response
 
@@ -175,7 +176,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
   def test_parser_encoding_when_searching_elements
     skip "Encoding not implemented" unless have_encoding?
 
-    body = '<span id="latin1">hi</span>'
+    body = +'<span id="latin1">hi</span>'
     page = util_page body, 'content-type' => 'text/html,charset=ISO-8859-1'
 
     result = page.search('#latin1')
@@ -187,7 +188,7 @@ class TestMechanizePageEncoding < Mechanize::TestCase
     skip if RUBY_ENGINE == 'jruby' # this is a libxml2-specific condition
 
     # https://github.com/sparklemotion/mechanize/issues/553
-    body = <<~EOF
+    body = +<<~EOF
       <html>
       <body>
       <!--

--- a/test/test_mechanize_page_frame.rb
+++ b/test/test_mechanize_page_frame.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePageFrame < Mechanize::TestCase

--- a/test/test_mechanize_page_image.rb
+++ b/test/test_mechanize_page_image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePageImage < Mechanize::TestCase

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 
@@ -11,7 +12,7 @@ class TestMechanizePageLink < Mechanize::TestCase
 <title>hi</title>
   HTML
 
-  BAD = <<-HTML
+  BAD = <<-HTML.dup
 <meta http-equiv="content-type" content="text/html; charset=windows-1255">
 <title>Bia\xB3ystok</title>
   HTML
@@ -19,18 +20,16 @@ class TestMechanizePageLink < Mechanize::TestCase
 
   SJIS_TITLE = "\x83\x65\x83\x58\x83\x67"
 
-  SJIS_AFTER_TITLE = <<-HTML
+  SJIS_AFTER_TITLE = <<-HTML.dup
 <title>#{SJIS_TITLE}</title>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
   HTML
-
   SJIS_AFTER_TITLE.force_encoding Encoding::BINARY if defined? Encoding
 
-  SJIS_BAD_AFTER_TITLE = <<-HTML
+  SJIS_BAD_AFTER_TITLE = <<-HTML.dup
 <title>#{SJIS_TITLE}</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   HTML
-
   SJIS_BAD_AFTER_TITLE.force_encoding Encoding::BINARY if defined? Encoding
 
   UTF8_TITLE = 'テスト'
@@ -46,7 +45,7 @@ class TestMechanizePageLink < Mechanize::TestCase
 
     @uri = URI('http://example')
     @res = { 'content-type' => 'text/html' }
-    @body = '<title>hi</title>'
+    @body = +'<title>hi</title>'
   end
 
   def util_page body = @body, res = @res
@@ -75,7 +74,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_canonical_uri_unescaped
-    page = util_page <<-BODY
+    page = util_page(+<<-BODY)
 <head>
   <link rel="canonical" href="http://example/white space"/>
 </head>
@@ -97,7 +96,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding
-    page = util_page WINDOWS_1255
+    page = util_page WINDOWS_1255.dup
 
     assert_equal 'windows-1255', page.encoding
   end
@@ -117,7 +116,7 @@ class TestMechanizePageLink < Mechanize::TestCase
     skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
     expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
-    page = util_page UTF8
+    page = util_page UTF8.dup
 
     assert_equal false, page.encoding_error?
 
@@ -141,7 +140,7 @@ class TestMechanizePageLink < Mechanize::TestCase
     skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
     expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
-    page = util_page "<title>#{UTF8_TITLE}</title>"
+    page = util_page(+"<title>#{UTF8_TITLE}</title>")
     page.encodings.replace %w[
       UTF-8
       Shift_JIS
@@ -153,7 +152,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_encoding_meta_charset
-    page = util_page "<meta charset='UTF-8'>"
+    page = util_page(+"<meta charset='UTF-8'>")
 
     assert_equal 'UTF-8', page.encoding
   end
@@ -344,7 +343,7 @@ class TestMechanizePageLink < Mechanize::TestCase
   end
 
   def test_title_none
-    page = util_page '' # invalid HTML
+    page = util_page(+'') # invalid HTML
 
     assert_nil(page.title)
   end

--- a/test/test_mechanize_page_meta_refresh.rb
+++ b/test/test_mechanize_page_meta_refresh.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePageMetaRefresh < Mechanize::TestCase

--- a/test/test_mechanize_parser.rb
+++ b/test/test_mechanize_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeParser < Mechanize::TestCase

--- a/test/test_mechanize_pluggable_parser.rb
+++ b/test/test_mechanize_pluggable_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizePluggableParser < Mechanize::TestCase

--- a/test/test_mechanize_redirect_limit_reached_error.rb
+++ b/test/test_mechanize_redirect_limit_reached_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeRedirectLimitReachedError < Mechanize::TestCase

--- a/test/test_mechanize_redirect_not_get_or_head_error.rb
+++ b/test/test_mechanize_redirect_not_get_or_head_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeRedirectNotGetOrHead < Mechanize::TestCase

--- a/test/test_mechanize_response_read_error.rb
+++ b/test/test_mechanize_response_read_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeResponseReadError < Mechanize::TestCase

--- a/test/test_mechanize_subclass.rb
+++ b/test/test_mechanize_subclass.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeSubclass < Mechanize::TestCase

--- a/test/test_mechanize_util.rb
+++ b/test/test_mechanize_util.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'mechanize/test_case'
 
@@ -6,7 +7,7 @@ class TestMechanizeUtil < Mechanize::TestCase
 
   INPUTTED_VALUE = "テスト" # "test" in Japanese UTF-8 encoding
   CONTENT_ENCODING = 'Shift_JIS' # one of Japanese encoding
-  ENCODED_VALUE = "\x83\x65\x83\x58\x83\x67".force_encoding(::Encoding::SHIFT_JIS) # "test" in Japanese Shift_JIS encoding
+  ENCODED_VALUE = "\x83\x65\x83\x58\x83\x67".dup.force_encoding(::Encoding::SHIFT_JIS) # "test" in Japanese Shift_JIS encoding
 
   ENCODING_ERRORS = [EncodingError, Encoding::ConverterNotFoundError] # and so on
   ERROR_LOG_MESSAGE = /from_native_charset: Encoding::ConverterNotFoundError: form encoding: "UTF-eight"/
@@ -67,7 +68,7 @@ class TestMechanizeUtil < Mechanize::TestCase
   end
 
   def test_from_native_charset_logs_form_when_encoding_error_raised
-    sio = StringIO.new("")
+    sio = StringIO.new
     log = Logger.new(sio)
     log.level = Logger::DEBUG
 
@@ -79,7 +80,7 @@ class TestMechanizeUtil < Mechanize::TestCase
   end
 
   def test_from_native_charset_logs_form_when_encoding_error_is_ignored
-    sio = StringIO.new("")
+    sio = StringIO.new
     log = Logger.new(sio)
     log.level = Logger::DEBUG
 

--- a/test/test_mechanize_xml_file.rb
+++ b/test/test_mechanize_xml_file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class TestMechanizeXmlFile < Mechanize::TestCase

--- a/test/test_multi_select.rb
+++ b/test/test_multi_select.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mechanize/test_case'
 
 class MultiSelectTest < Mechanize::TestCase


### PR DESCRIPTION
so that ruby 3.4 doesn't emit so many warnings.