### PR TITLE
fix broken link of "Test suite" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * https://www.rubydoc.info/gems/mechanize/
 * https://github.com/sparklemotion/mechanize
 
-[![Test suite](https://github.com/sparklemotion/mechanize/actions/workflows/ci-test.yml/badge.svg)](https://github.com/sparklemotion/mechanize/actions/workflows/ci-test.yml)
+[![Test suite](https://github.com/sparklemotion/mechanize/actions/workflows/ci.yml/badge.svg)](https://github.com/sparklemotion/mechanize/actions/workflows/ci.yml)
 
 
 ## Description


### PR DESCRIPTION
Hello, I noticed broken link of Test suite in README because of [this commit](https://github.com/sparklemotion/mechanize/commit/f89dc844c48dcb2bccdac81e1b08ef3455f8b2d6).
So, I fixed it.

Before
<img width="433" alt="image" src="https://github.com/sparklemotion/mechanize/assets/90303089/6c46c196-0243-4fad-a06a-f873751cac9a">
After
<img width="454" alt="image" src="https://github.com/sparklemotion/mechanize/assets/90303089/343c81b1-af9a-42f8-b08b-d5eb5ecd9ea0">
