### PR TITLE
fix: correctly recognize encoding errors in libxml >= 2.12.0

### DIFF
--- a/lib/mechanize/page.rb
+++ b/lib/mechanize/page.rb
@@ -101,6 +101,7 @@ class Mechanize::Page < Mechanize::File
     return false if parser.errors.empty?
     parser.errors.any? do |error|
       error.message.scrub =~ /(indicate\ encoding)|
+                              (Invalid\ bytes)|
                               (Invalid\ char)|
                               (input\ conversion\ failed)/x
     end

--- a/test/test_mechanize_page_link.rb
+++ b/test/test_mechanize_page_link.rb
@@ -114,13 +114,12 @@ class TestMechanizePageLink < Mechanize::TestCase
 
     # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
     skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
-    expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
     page = util_page UTF8.dup
 
     assert_equal false, page.encoding_error?
 
-    assert_equal expected_encoding, page.encoding
+    assert_equal "UTF-8", page.encoding
   end
 
   def test_encoding_charset_after_title_double_bad
@@ -138,7 +137,6 @@ class TestMechanizePageLink < Mechanize::TestCase
 
     # https://gitlab.gnome.org/GNOME/libxml2/-/issues/543
     skip if Nokogiri.uses_libxml?([">= 2.11.0", "< 2.12.0"])
-    expected_encoding = Nokogiri.uses_libxml?("< 2.11.0") ? 'UTF-8' : 'Shift_JIS'
 
     page = util_page(+"<title>#{UTF8_TITLE}</title>")
     page.encodings.replace %w[
@@ -148,7 +146,7 @@ class TestMechanizePageLink < Mechanize::TestCase
 
     assert_equal false, page.encoding_error?
 
-    assert_equal expected_encoding, page.encoding
+    assert_equal 'UTF-8', page.encoding
   end
 
   def test_encoding_meta_charset


### PR DESCRIPTION
Starting with libxml2 v2.12.0, encoding errors have a message that was not being detected by Page#encoding_error? resulting in a page that was parsed using incorrect encoding.

This change updates Page to detect those errors as _encoding errors_ and as a result we get the expected encoding back on the parsed document.