### PR TITLE
tidy: do not send the deprecated `accept-charset` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mechanize CHANGELOG
 
+## next / unreleased
+
+* The `accept-charset` header is no longer sent. In early versions of Mechanize, circa 2007, this was a common header but now no modern browser sends it, and servers are instructed to ignore it. See #646 for an example of a server that is confused by its presence. (#647) @flavorjones
+
+
 ## 2.10.1 / 2024-06-12
 
 * Improve page encoding error recovery on pages with broken encoding when used with libxml2 >= 2.12.0. (#644) @flavorjones

--- a/lib/mechanize/http/agent.rb
+++ b/lib/mechanize/http/agent.rb
@@ -581,7 +581,6 @@ class Mechanize::HTTP::Agent
   end
 
   def request_language_charset request
-    request['accept-charset']  = 'ISO-8859-1,utf-8;q=0.7,*;q=0.7'
     request['accept-language'] = 'en-us,en;q=0.5'
   end
 

--- a/test/test_mechanize_http_agent.rb
+++ b/test/test_mechanize_http_agent.rb
@@ -576,8 +576,8 @@ class TestMechanizeHttpAgent < Mechanize::TestCase
   def test_request_language_charset
     @agent.request_language_charset @req
 
-    assert_equal 'en-us,en;q=0.5', @req['accept-language']
-    assert_equal 'ISO-8859-1,utf-8;q=0.7,*;q=0.7', @req['accept-charset']
+    assert_equal('en-us,en;q=0.5', @req['accept-language'])
+    assert_nil(@req['accept-charset'])
   end
 
   def test_request_referer


### PR DESCRIPTION
See #646 for discussion.

Closes #647.