### PR TITLE
test: don't use minitest/pride

### DIFF
--- a/lib/mechanize/test_case.rb
+++ b/lib/mechanize/test_case.rb
@@ -15,11 +15,6 @@ end
 
 require 'minitest/autorun'
 
-begin
-  require 'minitest/pride'
-rescue LoadError
-end
-
 ##
 # A generic test case for testing mechanize.  Using a subclass of
 # Mechanize::TestCase for your tests will create an isolated mechanize


### PR DESCRIPTION
It broke in CI where the TERM env var is not set, see minitest/minitest#1009