### PR TITLE
Add Zstd support (optional dependency, just like Brotli)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,7 @@ gem "minitest", "~> 5.14"
 gem "rake", "~> 13.0"
 gem "rdoc", "~> 6.3"
 gem "rubocop", "~> 1.12"
-gem "brotli", ">= 0.5" unless RUBY_PLATFORM == "java"
+unless RUBY_PLATFORM == 'java'
+  gem 'brotli', '>= 0.5'
+  gem 'zstd-ruby', '~> 1.5'
+end


### PR DESCRIPTION
Just like #650 (adds brotli compression), this PR aims to give Mechanize support for Zstandard (zstd), in a similar way (will only work if you have the zstd-ruby gem installed).