### PR TITLE
fix: mime type string deprecation

### DIFF
--- a/lib/mechanize/pluggable_parsers.rb
+++ b/lib/mechanize/pluggable_parsers.rb
@@ -104,7 +104,7 @@ class Mechanize::PluggableParser
 
     return parser if parser
 
-    mime_type = MIME::Type.new content_type
+    mime_type = MIME::Type.new "content-type" => content_type
 
     parser = @parsers[mime_type.to_s] ||
              @parsers[mime_type.simplified] ||

--- a/mechanize.gemspec
+++ b/mechanize.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("addressable", "~> 2.8")
   spec.add_runtime_dependency("domain_name", ">= 0.5.20190701", "~> 0.5")
   spec.add_runtime_dependency("http-cookie", ">= 1.0.3", "~> 1.0")
-  spec.add_runtime_dependency("mime-types", "~> 3.0")
+  spec.add_runtime_dependency("mime-types", "~> 3.3")
   spec.add_runtime_dependency("net-http-digest_auth", ">= 1.4.1", "~> 1.4")
 
   # careful! some folks are relying on older versions of net-http-persistent


### PR DESCRIPTION
mime-types 3.6.0 warns "MIME::Type.MIME::Type.new when called with a String is deprecated."

change introduced in and syntax borrowed from:
https://github.com/mime-types/ruby-mime-types/commit/8512c1544e9b4a292284865c4d0c2b04e126fcc7