### PR TITLE
ci: drop jruby and truffleruby, add 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "jruby-9.4", "truffleruby"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["head", "jruby-head", "truffleruby-head"]
+        ruby-version: ["head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
-        with: { ruby-version: "3.3" }
+        with: { ruby-version: "3.4" }
       - run: |
           bundle add ${{matrix.name}} --git="${{matrix.git}}"
           bundle show


### PR DESCRIPTION
Dropping jruby and truffleruby from the test matrix.

We can add them back if they restabilize, but recently these tests have been very very noisy and simultaneously they are low value. And I am tired.
