### PR TITLE
quash Ruby 3.4 URI::Parser warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next / unreleased
 
 * Quash frozen string warnings in Ruby 3.4. (#661) @simpl1g
+* Quash URI::Parser warnings in Ruby 3.4. (#662) @flavorjones
 
 
 ## 2.12.2 / 2023-10-02

--- a/lib/mechanize/util.rb
+++ b/lib/mechanize/util.rb
@@ -134,29 +134,27 @@ class Mechanize::Util
   end
 
   def self.uri_escape str, unsafe = nil
-    @parser ||= begin
-                  URI::Parser.new
-                rescue NameError
-                  URI
-                end
-
-    if URI == @parser then
+    if URI == parser then
       unsafe ||= URI::UNSAFE
     else
-      unsafe ||= @parser.regexp[:UNSAFE]
+      unsafe ||= parser.regexp[:UNSAFE]
     end
 
-    @parser.escape str, unsafe
+    parser.escape str, unsafe
   end
 
   def self.uri_unescape str
-    @parser ||= begin
-                  URI::Parser.new
-                rescue NameError
-                  URI
-                end
-
-    @parser.unescape str
+    parser.unescape str
   end
 
+  def self.parser
+    @parser ||=
+      if defined?(URI::RFC2396_PARSER)
+        URI::RFC2396_PARSER
+      elsif defined?(URI::Parser)
+        URI::Parser.new
+      else
+        URI
+      end
+  end
 end


### PR DESCRIPTION
by using URI::RFC23996_PARSER directly if it exists.