### PR TITLE
Restore TruffleRuby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "head"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "head", "truffleruby"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["head"]
+        ruby-version: ["head", "truffleruby-head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Wondering if it's OK to add TruffleRuby back (both the last release and head). It was removed in a7f9461bbccafdb858d8ac706316adb1e4e7c6b8. Tests pass now (see https://github.com/andrykonchin/mechanize/pull/1).