### PR TITLE
test: update test documents to remove markup from frames/noframes

### DIFF
--- a/test/htdocs/frame_test.html
+++ b/test/htdocs/frame_test.html
@@ -18,13 +18,15 @@
   </IFRAME>
   </FRAMESET>
   <NOFRAMES>
-      <P>This frameset document contains:
-      <UL>
-         <LI><A href="/google.html">Some neat contents</A>
-         <LI><A href="/form_test.html" class="bar">Form Test</A>
-         <LI><A href="/file_upload.html">Some other neat contents</A>
-      </UL>
+    Your user agent does not support frames.
   </NOFRAMES>
+  <P>This frameset document contains:
+    <UL>
+      <LI><A href="/google.html">Some neat contents</A>
+      <LI><A href="/form_test.html" class="bar">Form Test</A>
+      <LI><A href="/file_upload.html">Some other neat contents</A>
+    </UL>
+  </P>
 </FRAMESET>
 </HTML>
 

--- a/test/htdocs/relative/tc_relative_links.html
+++ b/test/htdocs/relative/tc_relative_links.html
@@ -2,6 +2,7 @@
   <body>
     <a href="../tc_relative_links.html">dot dot slash</a>
     <a href="../../../../../tc_relative_links.html">too many dots</a>
+    <a href="?a=b">just the query string</A>
 <FRAMESET cols="20%, 80%">
   <FRAMESET rows="100, 200, 200">
   <FRAME name="frame1" src="../tc_relative_links.html">
@@ -13,7 +14,6 @@
   [Your user agent does not support frames or is currently configured
   not to display frames. However, you may visit
   <A href="foo.html">the related document.</A>]
-  <a href="?a=b">just the query string</A>
   </IFRAME>
   </FRAMESET>
 </FRAMESET>


### PR DESCRIPTION
In HTML5, frames/noframes content is raw text, not PCDATA; and libxml2 has implemented this behavior in v2.14.